### PR TITLE
Make allowed domain configurable

### DIFF
--- a/cloudformation/ELK_Stack_Multi_AZ.json
+++ b/cloudformation/ELK_Stack_Multi_AZ.json
@@ -50,6 +50,11 @@
             "Description": "Google OAuth 2.0 Client Secret",
             "Type": "String"
         },
+        "AllowedDomain": {
+            "Description": "Google apps domain eg. gmail.com or example.com",
+            "Type": "String",
+            "Default": "guardian.co.uk"
+        },
         "HostedZoneName": {
             "Description": "Route53 Hosted Zone in which kibana aliases will be created",
             "Type": "String"
@@ -180,6 +185,7 @@
                                 " -e 's,@@LOGCABIN_HOST,", { "Fn::GetAtt": [ "ElkLoadBalancer", "DNSName" ]}, ",g'",
                                 " -e 's,@@CLIENT_ID,", { "Ref": "GoogleOAuthClientId" }, ",g'",
                                 " -e 's,@@CLIENT_SECRET,", { "Ref": "GoogleOAuthClientSecret" }, ",g'",
+                                " -e 's,@@ALLOWED_DOMAIN,", { "Ref": "AllowedDomain" }, ",g'",
                                 " /opt/logcabin/config.js" ] ] },
                             "wget -O /etc/init/logcabin.conf https://raw.githubusercontent.com/guardian/elk-stack/master/config/upstart-logcabin.conf",
 

--- a/cloudformation/ELK_Stack_Multi_AZ_In_VPC.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_In_VPC.json
@@ -50,6 +50,11 @@
             "Description": "Google OAuth 2.0 Client Secret",
             "Type": "String"
         },
+        "AllowedDomain": {
+            "Description": "Google apps domain eg. gmail.com or example.com",
+            "Type": "String",
+            "Default": "guardian.co.uk"
+        },
         "VpcId": {
             "Description": "ID of the VPC onto which to launch the application eg. vpc-1234abcd",
             "Type": "String"
@@ -193,6 +198,7 @@
                                 " -e 's,@@LOGCABIN_HOST,", { "Fn::GetAtt": [ "ElkLoadBalancer", "DNSName" ]}, ",g'",
                                 " -e 's,@@CLIENT_ID,", { "Ref": "GoogleOAuthClientId" }, ",g'",
                                 " -e 's,@@CLIENT_SECRET,", { "Ref": "GoogleOAuthClientSecret" }, ",g'",
+                                " -e 's,@@ALLOWED_DOMAIN,", { "Ref": "AllowedDomain" }, ",g'",
                                 " /opt/logcabin/config.js" ] ] },
                             "wget -O /etc/init/logcabin.conf https://raw.githubusercontent.com/guardian/elk-stack/master/config/upstart-logcabin.conf",
 

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
@@ -55,6 +55,11 @@
             "Description": "Google OAuth 2.0 Client Secret",
             "Type": "String"
         },
+        "AllowedDomain": {
+            "Description": "Google apps domain eg. gmail.com or example.com",
+            "Type": "String",
+            "Default": "guardian.co.uk"
+        },
         "VpcId": {
             "Description": "ID of the VPC onto which to launch the application eg. vpc-1234abcd",
             "Type": "String"
@@ -223,6 +228,7 @@
                                 " -e 's,@@LOGCABIN_HOST,", { "Fn::GetAtt": [ "ElkPublicLoadBalancer", "DNSName" ]}, ",g'",
                                 " -e 's,@@CLIENT_ID,", { "Ref": "GoogleOAuthClientId" }, ",g'",
                                 " -e 's,@@CLIENT_SECRET,", { "Ref": "GoogleOAuthClientSecret" }, ",g'",
+                                " -e 's,@@ALLOWED_DOMAIN,", { "Ref": "AllowedDomain" }, ",g'",
                                 " /opt/logcabin/config.js" ] ] },
                             "wget -O /etc/init/logcabin.conf https://raw.githubusercontent.com/guardian/elk-stack/master/config/upstart-logcabin.conf",
 

--- a/config/config.js
+++ b/config/config.js
@@ -6,6 +6,7 @@ module.exports =  {
     // 'oauth_application_name': 'logcabin',
     'oauth_client_id': '@@CLIENT_ID',
     'oauth_client_secret': '@@CLIENT_SECRET',
+    'allowed_domain': '@ALLOWED_DOMAIN',
     'es_host': 'localhost',
     'es_port': 9200
 }

--- a/src/lib/google-oauth.js
+++ b/src/lib/google-oauth.js
@@ -69,7 +69,7 @@ function nonAuthenticated(config, url) {
 function findUser(profile, accessToken, config, callback)  {
     var username = profile.displayName || 'unknown'
 
-    if (profile._json.email.split('@')[1] === 'guardian.co.uk') {
+    if (profile._json.email.split('@')[1] === config.allowed_domain) {
         return callback(true, username)
     } else {
         console.log('access refused to: ' + username)


### PR DESCRIPTION
New option in configuration file for `allowed_domain`. Defaults to `guardian.co.uk` in the cloudformation template. Replace with your google app domain or `gmail.com`. Fixes #4.