### PR TITLE
Add HasDNS option for hosted zone

### DIFF
--- a/cloudformation/ELK_Stack_Multi_AZ.json
+++ b/cloudformation/ELK_Stack_Multi_AZ.json
@@ -56,9 +56,13 @@
             "Default": "guardian.co.uk"
         },
         "HostedZoneName": {
-            "Description": "Route53 Hosted Zone in which kibana aliases will be created",
+            "Description": "Route53 Hosted Zone in which kibana aliases will be created. Leave blank for no ALIAS.",
             "Type": "String"
         }
+    },
+
+    "Conditions": {
+        "HasDNS": { "Fn::Not" : [{"Fn::Equals" : [{"Ref" : "HostedZoneName"}, "" ] } ] }
     },
 
     "Resources": {
@@ -272,6 +276,7 @@
         },
         "KibanaAlias": {
             "Type" : "AWS::Route53::RecordSetGroup",
+            "Condition": "HasDNS",
             "Properties" : {
                 "HostedZoneName" : { "Ref": "HostedZoneName" },
                 "Comment" : "Alias to kibana elb",

--- a/cloudformation/ELK_Stack_Multi_AZ_In_VPC.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_In_VPC.json
@@ -64,9 +64,13 @@
             "Type": "CommaDelimitedList"
         },
         "HostedZoneName": {
-            "Description": "Route53 Hosted Zone in which kibana aliases will be created",
+            "Description": "Route53 Hosted Zone in which kibana aliases will be created. Leave blank for no ALIAS.",
             "Type": "String"
         }
+    },
+
+    "Conditions": {
+        "HasDNS": { "Fn::Not" : [{"Fn::Equals" : [{"Ref" : "HostedZoneName"}, "" ] } ] }
     },
 
     "Resources": {
@@ -331,6 +335,7 @@
         },
         "KibanaAlias": {
             "Type" : "AWS::Route53::RecordSetGroup",
+            "Condition": "HasDNS",
             "Properties" : {
                 "HostedZoneName" : { "Ref": "HostedZoneName" },
                 "Comment" : "Alias to kibana elb",

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
@@ -73,9 +73,13 @@
             "Type": "CommaDelimitedList"
         },
         "HostedZoneName": {
-            "Description": "Route53 Hosted Zone in which kibana aliases will be created",
+            "Description": "Route53 Hosted Zone in which kibana aliases will be created. Leave blank for no ALIAS.",
             "Type": "String"
         }
+    },
+
+    "Conditions": {
+        "HasDNS": { "Fn::Not" : [{"Fn::Equals" : [{"Ref" : "HostedZoneName"}, "" ] } ] }
     },
 
     "Resources": {
@@ -373,6 +377,7 @@
         },
         "KibanaAlias": {
             "Type" : "AWS::Route53::RecordSetGroup",
+            "Condition": "HasDNS",
             "Properties" : {
                 "HostedZoneName" : { "Ref": "HostedZoneName" },
                 "Comment" : "Alias to kibana elb",


### PR DESCRIPTION
If Route53 is not used or a alias is not required for Kibana then leave the `HostedZoneName` cloudformation parameter empty. Fixes #6.