### PR TITLE
Use AMI image appropriate for each region

### DIFF
--- a/cloudformation/ELK_Stack_Multi_AZ.json
+++ b/cloudformation/ELK_Stack_Multi_AZ.json
@@ -65,6 +65,19 @@
         "HasDNS": { "Fn::Not" : [{"Fn::Equals" : [{"Ref" : "HostedZoneName"}, "" ] } ] }
     },
 
+    "Mappings" : {
+        "RegionMap" : {
+            "us-east-1" :      { "ImageId": "ami-408c7f28" },
+            "us-west-2" :      { "ImageId": "ami-f34032c3" },
+            "us-west-1" :      { "ImageId": "ami-a26265e7" },
+            "eu-west-1" :      { "ImageId": "ami-cb4986bc" },
+            "ap-southeast-1" : { "ImageId": "ami-506d3102" },
+            "ap-southeast-2" : { "ImageId": "ami-7bb8dd41" },
+            "ap-northeast-1" : { "ImageId": "ami-19dd9218" },
+            "sa-east-1" :      { "ImageId": "ami-8f0aa692" }
+        }
+    },
+
     "Resources": {
 
         "ElkLoadBalancer": {
@@ -133,7 +146,7 @@
         "ElkLaunchConfig": {
             "Type": "AWS::AutoScaling::LaunchConfiguration",
             "Properties": {
-                "ImageId": "ami-cb4986bc",
+                "ImageId": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "ImageId" ]},
                 "SecurityGroups": [ { "Ref": "ElkSecurityGroup" } ],
                 "InstanceType": { "Ref": "ElkInstanceType" },
                 "IamInstanceProfile": { "Ref": "InstanceProfile" },

--- a/cloudformation/ELK_Stack_Multi_AZ_In_VPC.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_In_VPC.json
@@ -73,6 +73,19 @@
         "HasDNS": { "Fn::Not" : [{"Fn::Equals" : [{"Ref" : "HostedZoneName"}, "" ] } ] }
     },
 
+    "Mappings" : {
+        "RegionMap" : {
+            "us-east-1" :      { "ImageId": "ami-408c7f28" },
+            "us-west-2" :      { "ImageId": "ami-f34032c3" },
+            "us-west-1" :      { "ImageId": "ami-a26265e7" },
+            "eu-west-1" :      { "ImageId": "ami-cb4986bc" },
+            "ap-southeast-1" : { "ImageId": "ami-506d3102" },
+            "ap-southeast-2" : { "ImageId": "ami-7bb8dd41" },
+            "ap-northeast-1" : { "ImageId": "ami-19dd9218" },
+            "sa-east-1" :      { "ImageId": "ami-8f0aa692" }
+        }
+    },
+
     "Resources": {
 
         "ElkLoadBalancer": {
@@ -145,7 +158,7 @@
         "ElkLaunchConfig": {
             "Type": "AWS::AutoScaling::LaunchConfiguration",
             "Properties": {
-                "ImageId": "ami-cb4986bc",
+                "ImageId": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "ImageId" ]},
                 "SecurityGroups": [ { "Ref": "ElkSecurityGroup" }, { "Ref": "ElkLoadBalancerSecurityGroup" } ],
                 "InstanceType": { "Ref": "ElkInstanceType" },
                 "IamInstanceProfile": { "Ref": "InstanceProfile" },

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
@@ -82,6 +82,19 @@
         "HasDNS": { "Fn::Not" : [{"Fn::Equals" : [{"Ref" : "HostedZoneName"}, "" ] } ] }
     },
 
+    "Mappings" : {
+        "RegionMap" : {
+            "us-east-1" :      { "ImageId": "ami-408c7f28" },
+            "us-west-2" :      { "ImageId": "ami-f34032c3" },
+            "us-west-1" :      { "ImageId": "ami-a26265e7" },
+            "eu-west-1" :      { "ImageId": "ami-cb4986bc" },
+            "ap-southeast-1" : { "ImageId": "ami-506d3102" },
+            "ap-southeast-2" : { "ImageId": "ami-7bb8dd41" },
+            "ap-northeast-1" : { "ImageId": "ami-19dd9218" },
+            "sa-east-1" :      { "ImageId": "ami-8f0aa692" }
+        }
+    },
+
     "Resources": {
 
         "ElkPublicLoadBalancer": {
@@ -175,7 +188,7 @@
         "ElkLaunchConfig": {
             "Type": "AWS::AutoScaling::LaunchConfiguration",
             "Properties": {
-                "ImageId": "ami-cb4986bc",
+                "ImageId": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "ImageId" ]},
                 "SecurityGroups": [ { "Ref": "ElkSecurityGroup" }, { "Ref": "ElkPublicLoadBalancerSecurityGroup" }, { "Ref": "ElkInternalLoadBalancerSecurityGroup" } ],
                 "InstanceType": { "Ref": "ElkInstanceType" },
                 "IamInstanceProfile": { "Ref": "InstanceProfile" },

--- a/scripts/get_ami_images.sh
+++ b/scripts/get_ami_images.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+AMI_IMAGE_NAME="*ubuntu/images/ebs/ubuntu-trusty-14.04-amd64-server-20140607.1"
+
+# http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region
+
+for region in us-east-1 us-west-2 us-west-1 eu-west-1 eu-central-1 ap-southeast-1 ap-southeast-2 ap-northeast-1 sa-east-1
+do
+    printf "\"$region\" : {"
+    aws ec2 describe-images --filters Name=name,Values=$AMI_IMAGE_NAME --region $region | grep "ImageId" | sed s/,// | tr -d '\n'
+    printf "},\n"
+done


### PR DESCRIPTION
When the AMI image mapping needs to be updated run the script `get_ami_images.sh` with the new AMI image name then cut-and-paste the output into the cloudformation template (fixing for whitespace). This resolves #8.