### PR TITLE
Fix Google oAuth redirecting to ELB DNS

### DIFF
--- a/cloudformation/ELK_Stack_Multi_AZ_In_VPC.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_In_VPC.json
@@ -212,7 +212,7 @@
 
                             "wget -O /opt/logcabin/config.js https://raw.githubusercontent.com/guardian/elk-stack/master/config/config.js",
                             { "Fn::Join": [ "", [ "sed -i",
-                                " -e 's,@@LOGCABIN_HOST,", { "Fn::GetAtt": [ "ElkLoadBalancer", "DNSName" ]}, ",g'",
+                                " -e 's,@@LOGCABIN_HOST,", { "Fn::Join": ["", [ "kibana.", {"Ref": "HostedZoneName"} ]] }, ",g'",
                                 " -e 's,@@CLIENT_ID,", { "Ref": "GoogleOAuthClientId" }, ",g'",
                                 " -e 's,@@CLIENT_SECRET,", { "Ref": "GoogleOAuthClientSecret" }, ",g'",
                                 " -e 's,@@ALLOWED_DOMAIN,", { "Ref": "AllowedDomain" }, ",g'",


### PR DESCRIPTION
It set up `kibana.mydomain.com` but then Google oAuth would redirect to the ELB DNS instead. This fixes that, but doesn't handle the case where an ALIAS is not set up. My CloudFormation-fu doesn't go that far.

This is important if you want to use SSL to access Kibana.