### PR TITLE
Add AMI build of ELK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+accounts.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 accounts.json
+packer/*.pem

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,14 @@
 set -e
 
 # set PACKER_HOME if it isn't already provided
-[ -z "${PACKER_HOME}" ] && PACKER_HOME=/opt/packer
+[ -z "${PACKER_HOME}" ] && PACKER_HOME="/opt/packer"
+
+# set BUILD_NUMBER to DEV if not in TeamCity
+[ -z "${BUILD_NUMBER}"] && BUILD_NUMBER="DEV"
+
+# set BUILD_NUMBER to DEV if not in TeamCity
+BUILD_NAME=${TEAMCITY_PROJECT_NAME}-${TEAMCITY_BUILDCONF_NAME}
+[ -z "${TEAMCITY_BUILDCONF_NAME}" -o -z "${TEAMCITY_PROJECT_NAME}"] && BUILD_NAME="unknown"
 
 # ensure that we have AWS credentials (configure in TeamCity normally)
 # note that we don't actually use them in the script, the packer command does
@@ -15,6 +22,13 @@ then
   exit 1
 fi
 
+# Get all the account numbers of our AWS accounts
+PRISM_JSON=$(curl -s "http://prism.gutools.co.uk/sources?resource=instance&origin.vendor=aws")
+ACCOUNT_NUMBERS=$(echo ${PRISM_JSON} | jq '.data[].origin.accountNumber' | tr '\n' ',' | sed s/\"//g | sed s/,$//)
+echo "Account numbers for AMI: $ACCOUNT_NUMBERS"
+
 # now build
 echo "Building ELK AMI" 1>&2
-${PACKER_HOME}/packer build -color=false packer/elk.json
+${PACKER_HOME}/packer build -color=false packer/elk.json \
+  -var "build_number=${BUILD_NUMBER}" -var "build_name=${BUILD_NAME}" \
+  -var "account_numbers=${ACCOUNT_NUMBERS}

--- a/build.sh
+++ b/build.sh
@@ -17,4 +17,4 @@ fi
 
 # now build
 echo "Building ELK AMI" 1>&2
-${PACKER_HOME}/packer build -color=false elk.json
+${PACKER_HOME}/packer build -color=false packer/elk.json

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,10 @@
 # die if any command fails
 set -e
 
+DEBUG=""
+# set DEBUG flag if not in TeamCity
+[ -z "${BUILD_NUMBER}" ] && DEBUG="-debug"
+
 # set PACKER_HOME if it isn't already provided
 [ -z "${PACKER_HOME}" ] && PACKER_HOME="/opt/packer"
 
@@ -32,7 +36,7 @@ echo "Account numbers for AMI: $ACCOUNT_NUMBERS"
 
 # now build
 echo "Building ELK AMI" 1>&2
-${PACKER_HOME}/packer build -color=false \
+${PACKER_HOME}/packer build $DEBUG -color=false \
   -var "build_number=${BUILD_NUMBER}" -var "build_name=${BUILD_NAME}" \
   -var "build_branch=${BUILD_BRANCH}" -var "account_numbers=${ACCOUNT_NUMBERS}" \
   packer/elk.json

--- a/build.sh
+++ b/build.sh
@@ -1,42 +1,5 @@
 #!/bin/bash
-# Build packer AMI (on TeamCity host)
-
-# die if any command fails
 set -e
-
-DEBUG=""
-# set DEBUG flag if not in TeamCity
-[ -z "${BUILD_NUMBER}" ] && DEBUG="-debug"
-
-# set PACKER_HOME if it isn't already provided
-[ -z "${PACKER_HOME}" ] && PACKER_HOME="/opt/packer"
-
-# set BUILD_NUMBER to DEV if not in TeamCity
-[ -z "${BUILD_NUMBER}" ] && BUILD_NUMBER="DEV"
-
-# set BUILD_BRANCH if not in TeamCity
-[ -z "${BUILD_BRANCH}" ] && BUILD_BRANCH="DEV"
-
-# set BUILD_NUMBER to DEV if not in TeamCity
-BUILD_NAME=${TEAMCITY_PROJECT_NAME}-${TEAMCITY_BUILDCONF_NAME}
-[ -z "${TEAMCITY_BUILDCONF_NAME}" -o -z "${TEAMCITY_PROJECT_NAME}" ] && BUILD_NAME="unknown"
-
-# ensure that we have AWS credentials (configure in TeamCity normally)
-# note that we don't actually use them in the script, the packer command does
-if [ -z "${AWS_ACCESS_KEY}" -o -z "${AWS_SECRET_KEY}" ]
-then
-  echo "AWS_ACCESS_KEY and AWS_SECRET_KEY environment variables must be set" 1>&2
-  exit 1
-fi
-
-# Get all the account numbers of our AWS accounts
-PRISM_JSON=$(curl -s "http://prism.gutools.co.uk/sources?resource=instance&origin.vendor=aws")
-ACCOUNT_NUMBERS=$(echo ${PRISM_JSON} | jq '.data[].origin.accountNumber' | tr '\n' ',' | sed s/\"//g | sed s/,$//)
-echo "Account numbers for AMI: $ACCOUNT_NUMBERS"
-
-# now build
-echo "Building ELK AMI" 1>&2
-${PACKER_HOME}/packer build $DEBUG -color=false \
-  -var "build_number=${BUILD_NUMBER}" -var "build_name=${BUILD_NAME}" \
-  -var "build_branch=${BUILD_BRANCH}" -var "account_numbers=${ACCOUNT_NUMBERS}" \
-  packer/elk.json
+pushd packer
+bash build.sh
+popd

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,9 @@ set -e
 # set BUILD_NUMBER to DEV if not in TeamCity
 [ -z "${BUILD_NUMBER}" ] && BUILD_NUMBER="DEV"
 
+# set BUILD_BRANCH if not in TeamCity
+[ -z "${BUILD_BRANCH}" ] && BUILD_BRANCH="DEV"
+
 # set BUILD_NUMBER to DEV if not in TeamCity
 BUILD_NAME=${TEAMCITY_PROJECT_NAME}-${TEAMCITY_BUILDCONF_NAME}
 [ -z "${TEAMCITY_BUILDCONF_NAME}" -o -z "${TEAMCITY_PROJECT_NAME}" ] && BUILD_NAME="unknown"
@@ -31,4 +34,5 @@ echo "Account numbers for AMI: $ACCOUNT_NUMBERS"
 echo "Building ELK AMI" 1>&2
 ${PACKER_HOME}/packer build -color=false \
   -var "build_number=${BUILD_NUMBER}" -var "build_name=${BUILD_NAME}" \
-  -var "account_numbers=${ACCOUNT_NUMBERS}" packer/elk.json
+  -var "build_branch=${BUILD_BRANCH}" -var "account_numbers=${ACCOUNT_NUMBERS}" \
+  packer/elk.json

--- a/build.sh
+++ b/build.sh
@@ -8,11 +8,11 @@ set -e
 [ -z "${PACKER_HOME}" ] && PACKER_HOME="/opt/packer"
 
 # set BUILD_NUMBER to DEV if not in TeamCity
-[ -z "${BUILD_NUMBER}"] && BUILD_NUMBER="DEV"
+[ -z "${BUILD_NUMBER}" ] && BUILD_NUMBER="DEV"
 
 # set BUILD_NUMBER to DEV if not in TeamCity
 BUILD_NAME=${TEAMCITY_PROJECT_NAME}-${TEAMCITY_BUILDCONF_NAME}
-[ -z "${TEAMCITY_BUILDCONF_NAME}" -o -z "${TEAMCITY_PROJECT_NAME}"] && BUILD_NAME="unknown"
+[ -z "${TEAMCITY_BUILDCONF_NAME}" -o -z "${TEAMCITY_PROJECT_NAME}" ] && BUILD_NAME="unknown"
 
 # ensure that we have AWS credentials (configure in TeamCity normally)
 # note that we don't actually use them in the script, the packer command does
@@ -29,6 +29,6 @@ echo "Account numbers for AMI: $ACCOUNT_NUMBERS"
 
 # now build
 echo "Building ELK AMI" 1>&2
-${PACKER_HOME}/packer build -color=false packer/elk.json \
+${PACKER_HOME}/packer build -color=false \
   -var "build_number=${BUILD_NUMBER}" -var "build_name=${BUILD_NAME}" \
-  -var "account_numbers=${ACCOUNT_NUMBERS}
+  -var "account_numbers=${ACCOUNT_NUMBERS}" packer/elk.json

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
@@ -55,6 +55,10 @@
             "Description": "Google OAuth 2.0 Client Secret",
             "Type": "String"
         },
+        "GoogleAuthDomain": {
+          "Description": "The allowed domain for authenticated users",
+          "Type": "String"
+        },
         "VpcId": {
             "Description": "ID of the VPC onto which to launch the application eg. vpc-1234abcd",
             "Type": "String"
@@ -207,6 +211,7 @@
                                   ]}, ",g'",
                                 " -e 's,@@CLIENT_ID,", { "Ref": "GoogleOAuthClientId" }, ",g'",
                                 " -e 's,@@CLIENT_SECRET,", { "Ref": "GoogleOAuthClientSecret" }, ",g'",
+                                " -e 's,@@ALLOWED_DOMAIN,", { "Ref": "GoogleAuthDomain" }, ",g'",
                                 " /opt/logcabin/config.js.template > /opt/logcabin/config.js" ] ] },
 
                             "start elasticsearch",

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
@@ -195,7 +195,7 @@
                 "SecurityGroups": [ { "Ref": "ElkSecurityGroup" }, { "Ref": "ElkPublicLoadBalancerSecurityGroup" }, { "Ref": "ElkInternalLoadBalancerSecurityGroup" } ],
                 "InstanceType": { "Ref": "ElkInstanceType" },
                 "IamInstanceProfile": { "Ref": "InstanceProfile" },
-                "AssociatePublicIpAddress": "True",
+                "AssociatePublicIpAddress": "False",
                 "KeyName": { "Ref": "KeyName" },
                 "UserData": {
                     "Fn::Base64": {

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
@@ -28,11 +28,6 @@
             "MinValue": 1,
             "MaxValue": 12
         },
-        "ElkMinNodes": {
-            "Description": "The minimum number of nodes that can form a cluster (should be n/2 + 1, e.g. for 3 nodes this should be 2)",
-            "Type": "Number",
-            "Default": "1"
-        },
         "ElkInstanceType": {
             "Description": "EC2 instance type",
             "Type": "String",
@@ -201,13 +196,15 @@
                     "Fn::Base64": {
                         "Fn::Join": [ "\n", [
                             "#!/bin/bash -v",
+                            "set -e",
                             "chown elasticsearch /data",
+                            "MINIMUM_NODES=$(expr ",{ "Ref": "ElkCapacity" }," / 2 + 1)"
 
                             { "Fn::Join": [ "", [ "sed",
                                 " -e 's,@@REGION,", { "Ref": "AWS::Region" }, ",g'",
                                 " -e 's,@@STACK,", { "Ref": "Stack" }, ",g'",
                                 " -e 's,@@APP,kibana,g'",
-                                " -e 's,@@MINIMUM_NODES,", { "Ref": "ElkMinNodes" }, ",g'",
+                                " -e 's,@@MINIMUM_NODES,${MINIMUM_NODES},g'",
                                 " /etc/elasticsearch/elasticsearch.yml.template > /etc/elasticsearch/elasticsearch.yml" ] ] },
 
                             { "Fn::Join": [ "", [ "sed",

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
@@ -1,0 +1,368 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+
+    "Description": "ELK Stack - Elasticsearch, Logstash, Kibana",
+
+    "Parameters": {
+
+        "Stack": {
+            "Description": "Stack applied as a tag",
+            "Type": "String"
+        },
+        "KeyName": {
+            "Default": "bootstrap",
+            "Description": "Name of an existing EC2 KeyPair for SSH access",
+            "Type": "String"
+        },
+        "Stage": {
+            "Description": "Stage applied as a tag",
+            "Type": "String",
+            "Default": "PROD",
+            "AllowedValues": [ "PROD", "CODE" ],
+            "ConstraintDescription": "must be a valid stage eg. PROD, CODE"
+        },
+        "ElkCapacity": {
+            "Description": "Autoscale Size",
+            "Type": "Number",
+            "Default": "1",
+            "MinValue": 1,
+            "MaxValue": 12
+        },
+        "ElkInstanceType": {
+            "Description": "EC2 instance type",
+            "Type": "String",
+            "Default": "m1.large",
+            "AllowedValues": [
+                "t1.micro",
+                "m1.small",
+                "m1.medium",
+                "m1.large",
+                "m2.xlarge",
+                "m3.medium",
+                "m3.large",
+                "m3.xlarge",
+                "m3.2xlarge",
+                "c1.medium",
+                "c3.large"
+            ],
+            "ConstraintDescription": "must be a valid EC2 instance type"
+        },
+        "GoogleOAuthClientId": {
+            "Description": "Google OAuth 2.0 Client ID",
+            "Type": "String"
+        },
+        "GoogleOAuthClientSecret": {
+            "Description": "Google OAuth 2.0 Client Secret",
+            "Type": "String"
+        },
+        "VpcId": {
+            "Description": "ID of the VPC onto which to launch the application eg. vpc-1234abcd",
+            "Type": "String"
+        },
+        "PublicVpcSubnets" : {
+            "Description": "Subnets to use in VPC for public ELB eg. subnet-abcd1234",
+            "Type": "CommaDelimitedList"
+        },
+        "PrivateVpcSubnets" : {
+            "Description": "Subnets to use in VPC for instances eg. subnet-abcd1234",
+            "Type": "CommaDelimitedList"
+        },
+        "HostedZoneName": {
+            "Description": "Route53 Hosted Zone in which kibana aliases will be created",
+            "Type": "String"
+        }
+    },
+
+    "Resources": {
+
+        "ElkPublicLoadBalancer": {
+            "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+            "Properties": {
+                "CrossZone": true,
+                "Listeners": [
+                    {
+                        "Protocol": "HTTP",
+                        "LoadBalancerPort": "80",
+                        "InstancePort": "8080"
+                    }
+                ],
+                "HealthCheck": {
+                    "Target": "HTTP:8080/__es/",
+                    "Timeout": "10",
+                    "Interval": "20",
+                    "UnhealthyThreshold": "10",
+                    "HealthyThreshold": "2"
+                },
+                "Subnets": { "Ref": "PublicVpcSubnets" },
+                "SecurityGroups": [
+                    { "Ref": "ElkPublicLoadBalancerSecurityGroup" }
+                ]
+            }
+        },
+
+        "ElkInternalLoadBalancer": {
+            "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+            "Properties": {
+                "Scheme": "internal",
+                "CrossZone": true,
+                "Listeners": [
+                    {
+                        "Protocol": "TCP",
+                        "LoadBalancerPort": "6379",
+                        "InstancePort": "6379"
+                    }
+                ],
+                "HealthCheck": {
+                    "Target": "TCP:6379",
+                    "Timeout": "10",
+                    "Interval": "20",
+                    "UnhealthyThreshold": "10",
+                    "HealthyThreshold": "2"
+                },
+                "Subnets": { "Ref": "PrivateVpcSubnets" },
+                "SecurityGroups": [
+                    { "Ref": "ElkInternalLoadBalancerSecurityGroup" }
+                ]
+            }
+        },
+
+        "ElkAutoscalingGroup": {
+            "Type": "AWS::AutoScaling::AutoScalingGroup",
+            "Properties": {
+                "AvailabilityZones": { "Fn::GetAZs": "" },
+                "VPCZoneIdentifier": { "Ref": "PrivateVpcSubnets" },
+                "LaunchConfigurationName": { "Ref": "ElkLaunchConfig" },
+                "MinSize": "1",
+                "MaxSize": "12",
+                "DesiredCapacity": { "Ref": "ElkCapacity" },
+                "HealthCheckType": "ELB",
+                "HealthCheckGracePeriod": 300,
+                "LoadBalancerNames": [ { "Ref": "ElkPublicLoadBalancer" }, { "Ref": "ElkInternalLoadBalancer" } ],
+                "Tags": [
+                    {
+                        "Key": "Stage",
+                        "Value": { "Ref": "Stage" },
+                        "PropagateAtLaunch": "true"
+                    },
+                    {
+                        "Key": "Stack",
+                        "Value": { "Ref": "Stack" },
+                        "PropagateAtLaunch": "true"
+                    },
+                    {
+                        "Key": "App",
+                        "Value": "kibana",
+                        "PropagateAtLaunch": "true"
+                    },
+                    {
+                        "Key": "Name",
+                        "Value": "kibana",
+                        "PropagateAtLaunch": "true"
+                    }
+                ]
+            }
+        },
+
+        "ElkLaunchConfig": {
+            "Type": "AWS::AutoScaling::LaunchConfiguration",
+            "Properties": {
+                "ImageId": "ami-cb4986bc",
+                "SecurityGroups": [ { "Ref": "ElkSecurityGroup" }, { "Ref": "ElkPublicLoadBalancerSecurityGroup" }, { "Ref": "ElkInternalLoadBalancerSecurityGroup" } ],
+                "InstanceType": { "Ref": "ElkInstanceType" },
+                "IamInstanceProfile": { "Ref": "InstanceProfile" },
+                "AssociatePublicIpAddress": "True",
+                "KeyName": { "Ref": "KeyName" },
+                "UserData": {
+                    "Fn::Base64": {
+                        "Fn::Join": [ "\n", [
+                            "#!/bin/bash -v",
+
+                            { "Fn::Join": [ "", [ "sed",
+                                " -e 's,@@REGION,", { "Ref": "AWS::Region" }, ",g'",
+                                " -e 's,@@STACK,", { "Ref": "Stack" }, ",g'",
+                                " -e 's,@@APP,kibana,g'",
+                                " /etc/elasticsearch/elasticsearch.yml.template > /etc/elasticsearch/elasticsearch.yml" ] ] },
+
+                            { "Fn::Join": [ "", [ "sed",
+                                " -e 's,@@LOGCABIN_HOST,", { "Fn::GetAtt": [ "ElkPublicLoadBalancer", "DNSName" ]}, ",g'",
+                                " -e 's,@@CLIENT_ID,", { "Ref": "GoogleOAuthClientId" }, ",g'",
+                                " -e 's,@@CLIENT_SECRET,", { "Ref": "GoogleOAuthClientSecret" }, ",g'",
+                                " /opt/logcabin/config.js.template > /opt/logcabin/config.js" ] ] },
+
+                            "restart logstash",
+                            "restart elasticsearch",
+                            "restart logcabin"
+                        ] ]
+                    }
+                }
+            }
+        },
+
+        "ElkPublicLoadBalancerSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Properties": {
+                "VpcId": { "Ref": "VpcId" },
+                "GroupDescription": "Allow access to kibana on public ELB from internet",
+                "SecurityGroupIngress": [
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "80",
+                        "ToPort": "80",
+                        "CidrIp": "0.0.0.0/0"
+                    }
+                ],
+                "SecurityGroupEgress": [
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "8080",
+                        "ToPort": "8080",
+                        "CidrIp": "0.0.0.0/0"
+                    }
+                ]
+            }
+        },
+
+        "ElkInternalLoadBalancerSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Properties": {
+                "VpcId": { "Ref": "VpcId" },
+                "GroupDescription": "Allow logstash messages to internal ELB",
+                "SecurityGroupIngress": [
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "6379",
+                        "ToPort": "6379",
+                        "CidrIp": "0.0.0.0/0"
+                    }
+                ],
+                "SecurityGroupEgress": [
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "6379",
+                        "ToPort": "6379",
+                        "CidrIp": "0.0.0.0/0"
+                    }
+                ]
+            }
+        },
+
+        "ElkSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Properties": {
+                "GroupDescription": "Allow kibana from public and logstash from internal ELBs",
+                "VpcId": { "Ref": "VpcId" },
+                "SecurityGroupIngress": [
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "6379",
+                        "ToPort": "6379",
+                        "SourceSecurityGroupId": { "Ref": "ElkInternalLoadBalancerSecurityGroup" }
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "8080",
+                        "ToPort": "8080",
+                        "SourceSecurityGroupId": { "Ref": "ElkPublicLoadBalancerSecurityGroup" }
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "22",
+                        "ToPort": "22",
+                        "CidrIp": "77.91.248.0/21"
+                    }
+                ]
+            }
+        },
+
+        "ElkSecurityGroupIngress": {
+            "Type": "AWS::EC2::SecurityGroupIngress",
+            "Properties": {
+                "GroupId": { "Fn::GetAtt": [ "ElkSecurityGroup", "GroupId" ] },
+                "IpProtocol": "tcp",
+                "FromPort": "9300",
+                "ToPort": "9305",
+                "SourceSecurityGroupId": { "Fn::GetAtt": [ "ElkSecurityGroup", "GroupId" ] }
+            }
+        },
+
+        "Role": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "Path": "/",
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": "sts:AssumeRole",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [ "ec2.amazonaws.com" ]
+                            }
+                        }
+                    ]
+                },
+                "Policies": [
+                    {
+                        "PolicyName":"ec2-describe-instances",
+                        "PolicyDocument": {
+                            "Version" : "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Action": "ec2:DescribeInstances",
+                                    "Effect": "Allow",
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "InstanceProfile": {
+            "Type": "AWS::IAM::InstanceProfile",
+            "Properties": {
+                "Path": "/",
+                "Roles": [ { "Ref": "Role" } ]
+            }
+        },
+        "KibanaAlias": {
+            "Type" : "AWS::Route53::RecordSetGroup",
+            "Properties" : {
+                "HostedZoneName" : { "Ref": "HostedZoneName" },
+                "Comment" : "Alias to kibana elb",
+                "RecordSets" : [
+                    {
+                        "Name" : { "Fn::Join": ["", [ "kibana.", {"Ref": "HostedZoneName"} ]] },
+                        "Type" : "A",
+                        "AliasTarget" : {
+                           "HostedZoneId" : { "Fn::GetAtt" : ["ElkPublicLoadBalancer", "CanonicalHostedZoneNameID"] },
+                            "DNSName" : { "Fn::GetAtt" : ["ElkPublicLoadBalancer","DNSName"] }
+                        }
+                    },
+                    {
+                        "Name" : { "Fn::Join": ["", [ "logstash.", {"Ref": "HostedZoneName"} ]] },
+                        "Type" : "A",
+                        "AliasTarget" : {
+                           "HostedZoneId" : { "Fn::GetAtt" : ["ElkInternalLoadBalancer", "CanonicalHostedZoneNameID"] },
+                            "DNSName" : { "Fn::GetAtt" : ["ElkInternalLoadBalancer","DNSName"] }
+                        }
+                    }
+                ]
+            }
+        }
+    },
+
+    "Outputs": {
+        "LogstashEndpoint": {
+            "Value": { "Fn::Join": ["", [ { "Fn::GetAtt": [ "ElkInternalLoadBalancer", "DNSName" ]}, ":6379"]] },
+            "Description": "Logging endpoint for Logstash TCP input"
+        },
+        "KibanaURL": {
+            "Value": { "Fn::Join": ["", ["http://", { "Fn::GetAtt": [ "ElkPublicLoadBalancer", "DNSName" ]}, "/#/dashboard/file/logstash.json"]] },
+            "Description": "URL for the Kibana Dashboard"
+        },
+        "GoogleOAuthRedirectUrl": {
+            "Value": { "Fn::Join": ["", ["http://", { "Fn::GetAtt": [ "ElkPublicLoadBalancer", "DNSName" ]}, "/auth/google/callback"]] },
+            "Description": "Redirect URL for the Google Developers Console"
+        }
+    }
+}

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
@@ -209,9 +209,10 @@
                                 " -e 's,@@CLIENT_SECRET,", { "Ref": "GoogleOAuthClientSecret" }, ",g'",
                                 " /opt/logcabin/config.js.template > /opt/logcabin/config.js" ] ] },
 
-                            "restart elasticsearch",
+                            "start elasticsearch",
                             "restart logstash",
-                            "restart logcabin"
+                            "restart logstash-web",
+                            "start logcabin"
                         ] ]
                     }
                 }

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
@@ -28,6 +28,11 @@
             "MinValue": 1,
             "MaxValue": 12
         },
+        "ElkMinNodes": {
+            "Description": "The minimum number of nodes that can form a cluster (should be n/2 + 1, e.g. for 3 nodes this should be 2)",
+            "Type": "Number",
+            "Default": "1"
+        },
         "ElkInstanceType": {
             "Description": "EC2 instance type",
             "Type": "String",
@@ -152,7 +157,7 @@
                 "AvailabilityZones": { "Fn::GetAZs": "" },
                 "VPCZoneIdentifier": { "Ref": "PrivateVpcSubnets" },
                 "LaunchConfigurationName": { "Ref": "ElkLaunchConfig" },
-                "MinSize": "1",
+                "MinSize": { "Ref": "ElkCapacity" },
                 "MaxSize": "12",
                 "DesiredCapacity": { "Ref": "ElkCapacity" },
                 "HealthCheckType": "ELB",
@@ -202,6 +207,7 @@
                                 " -e 's,@@REGION,", { "Ref": "AWS::Region" }, ",g'",
                                 " -e 's,@@STACK,", { "Ref": "Stack" }, ",g'",
                                 " -e 's,@@APP,kibana,g'",
+                                " -e 's,@@MINIMUM_NODES,", { "Ref": "ElkMinNodes" }, ",g'",
                                 " /etc/elasticsearch/elasticsearch.yml.template > /etc/elasticsearch/elasticsearch.yml" ] ] },
 
                             { "Fn::Join": [ "", [ "sed",

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
@@ -84,11 +84,17 @@
           "Description": "ARN of the SSL certificate for *.gutools.co.uk",
           "Type": "String",
           "Default": "arn:aws:iam::743583969668:server-certificate/sites.gutools.co.uk-exp2015-10-20"
+        },
+        "SnapshotBucket": {
+            "Description": "The name of the S3 bucket to configure for creating and restoring snapshots",
+            "Type": "String",
+            "Default": ""
         }
     },
 
     "Conditions": {
-        "HostnameSpecified": {"Fn::Not": [{"Fn::Equals": [{"Ref": "Hostname"}, ""]}]}
+        "HostnameSpecified": {"Fn::Not": [{"Fn::Equals": [{"Ref": "Hostname"}, ""]}]},
+        "SnapshotBucketSpecified": {"Fn::Not": [{"Fn::Equals": [{"Ref": "SnapshotBucket"}, ""]}]}
     },
 
     "Resources": {
@@ -328,22 +334,61 @@
                             }
                         }
                     ]
+                }
+            }
+        },
+        "DescribeInstancesPolicy": {
+            "Type": "AWS::IAM::Policy",
+            "Properties": {
+                "PolicyName":"ec2-describe-instances",
+                "PolicyDocument": {
+                    "Version" : "2012-10-17",
+                    "Statement": [
+                        {
+                            "Action": "ec2:DescribeInstances",
+                            "Effect": "Allow",
+                            "Resource": "*"
+                        }
+                    ]
                 },
-                "Policies": [
-                    {
-                        "PolicyName":"ec2-describe-instances",
-                        "PolicyDocument": {
-                            "Version" : "2012-10-17",
-                            "Statement": [
-                                {
-                                    "Action": "ec2:DescribeInstances",
-                                    "Effect": "Allow",
-                                    "Resource": "*"
-                                }
+                "Roles": [{"Ref": "Role"}]
+            }
+        },
+        "SnapshotBucketPolicy": {
+            "Type": "AWS::IAM::Policy",
+            "Condition" : "SnapshotBucketSpecified",
+            "Properties": {
+                "PolicyName":"SnapshotBucketPolicy",
+                "PolicyDocument": {
+                    "Version" : "2012-10-17",
+                    "Statement": [
+                        {
+                            "Action": [
+                                "s3:ListBucket"
+                            ],
+                            "Effect": "Allow",
+                            "Resource": [
+                              { "Fn::Join": [ "",
+                                [ "arn:aws:s3:::", { "Ref" : "SnapshotBucket"} ]
+                              ] }
+                            ]
+                        },
+                        {
+                            "Action": [
+                                "s3:GetObject",
+                                "s3:PutObject",
+                                "s3:DeleteObject"
+                            ],
+                            "Effect": "Allow",
+                            "Resource": [
+                              { "Fn::Join": [ "",
+                                [ "arn:aws:s3:::", { "Ref" : "SnapshotBucket"}, "/*" ]
+                              ] }
                             ]
                         }
-                    }
-                ]
+                    ]
+                },
+                "Roles": [{"Ref": "Role"}]
             }
         },
         "InstanceProfile": {

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
@@ -198,13 +198,13 @@
                             "#!/bin/bash -v",
                             "set -e",
                             "chown elasticsearch /data",
-                            "MINIMUM_NODES=$(expr ",{ "Ref": "ElkCapacity" }," / 2 + 1)"
+                            { "Fn::Join": [ "", [ "MINIMUM_NODES=$(expr ", { "Ref": "ElkCapacity" }, " / 2 + 1)" ] ] },
 
                             { "Fn::Join": [ "", [ "sed",
                                 " -e 's,@@REGION,", { "Ref": "AWS::Region" }, ",g'",
                                 " -e 's,@@STACK,", { "Ref": "Stack" }, ",g'",
                                 " -e 's,@@APP,kibana,g'",
-                                " -e 's,@@MINIMUM_NODES,${MINIMUM_NODES},g'",
+                                " -e \"s,@@MINIMUM_NODES,${MINIMUM_NODES},g\"",
                                 " /etc/elasticsearch/elasticsearch.yml.template > /etc/elasticsearch/elasticsearch.yml" ] ] },
 
                             { "Fn::Join": [ "", [ "sed",

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
@@ -71,6 +71,11 @@
             "Description": "The AMI produced by the elk.json packer build in github.com/guardian/elk-stack",
             "Type": "String"
         },
+        "Hostname": {
+            "Description": "The public hostname to be used - if blank, then the public load balancer name will be used",
+            "Type": "String",
+            "Default": ""
+        },
         "SSLCertificateId": {
           "Description": "ARN of the SSL certificate for *.gutools.co.uk",
           "Type": "String",
@@ -78,8 +83,11 @@
         }
     },
 
-    "Resources": {
+    "Conditions": {
+        "HostnameSpecified": {"Fn::Not": [{"Fn::Equals": [{"Ref": "Hostname"}, ""]}]}
+    },
 
+    "Resources": {
         "ElkPublicLoadBalancer": {
             "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
             "Properties": {
@@ -184,6 +192,7 @@
                     "Fn::Base64": {
                         "Fn::Join": [ "\n", [
                             "#!/bin/bash -v",
+                            "chown elasticsearch /data",
 
                             { "Fn::Join": [ "", [ "sed",
                                 " -e 's,@@REGION,", { "Ref": "AWS::Region" }, ",g'",
@@ -192,13 +201,16 @@
                                 " /etc/elasticsearch/elasticsearch.yml.template > /etc/elasticsearch/elasticsearch.yml" ] ] },
 
                             { "Fn::Join": [ "", [ "sed",
-                                " -e 's,@@LOGCABIN_HOST,", { "Fn::GetAtt": [ "ElkPublicLoadBalancer", "DNSName" ]}, ",g'",
+                                " -e 's,@@LOGCABIN_HOST,", {"Fn::If": ["HostnameSpecified",
+                                  { "Ref": "Hostname" },
+                                  { "Fn::GetAtt": [ "ElkPublicLoadBalancer", "DNSName" ]}
+                                  ]}, ",g'",
                                 " -e 's,@@CLIENT_ID,", { "Ref": "GoogleOAuthClientId" }, ",g'",
                                 " -e 's,@@CLIENT_SECRET,", { "Ref": "GoogleOAuthClientSecret" }, ",g'",
                                 " /opt/logcabin/config.js.template > /opt/logcabin/config.js" ] ] },
 
-                            "restart logstash",
                             "restart elasticsearch",
+                            "restart logstash",
                             "restart logcabin"
                         ] ]
                     }

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
@@ -67,13 +67,14 @@
             "Description": "Subnets to use in VPC for instances eg. subnet-abcd1234",
             "Type": "CommaDelimitedList"
         },
-        "HostedZoneName": {
-            "Description": "Route53 Hosted Zone in which kibana aliases will be created",
-            "Type": "String"
-        },
         "PackerAMI": {
             "Description": "The AMI produced by the elk.json packer build in github.com/guardian/elk-stack",
             "Type": "String"
+        },
+        "SSLCertificateId": {
+          "Description": "ARN of the SSL certificate for *.gutools.co.uk",
+          "Type": "String",
+          "Default": "arn:aws:iam::743583969668:server-certificate/sites.gutools.co.uk-exp2015-10-20"
         }
     },
 
@@ -85,9 +86,12 @@
                 "CrossZone": true,
                 "Listeners": [
                     {
-                        "Protocol": "HTTP",
-                        "LoadBalancerPort": "80",
-                        "InstancePort": "8080"
+                        "Protocol": "HTTPS",
+                        "LoadBalancerPort": "443",
+                        "InstancePort": "8080",
+                        "SSLCertificateId": {
+                          "Ref": "SSLCertificateId"
+                        }
                     }
                 ],
                 "HealthCheck": {
@@ -210,8 +214,8 @@
                 "SecurityGroupIngress": [
                     {
                         "IpProtocol": "tcp",
-                        "FromPort": "80",
-                        "ToPort": "80",
+                        "FromPort": "443",
+                        "ToPort": "443",
                         "CidrIp": "0.0.0.0/0"
                     }
                 ],
@@ -272,7 +276,7 @@
                         "IpProtocol": "tcp",
                         "FromPort": "22",
                         "ToPort": "22",
-                        "CidrIp": "77.91.248.0/21"
+                        "CidrIp": "10.0.0.0/8"
                     }
                 ]
             }
@@ -327,31 +331,6 @@
                 "Path": "/",
                 "Roles": [ { "Ref": "Role" } ]
             }
-        },
-        "KibanaAlias": {
-            "Type" : "AWS::Route53::RecordSetGroup",
-            "Properties" : {
-                "HostedZoneName" : { "Ref": "HostedZoneName" },
-                "Comment" : "Alias to kibana elb",
-                "RecordSets" : [
-                    {
-                        "Name" : { "Fn::Join": ["", [ "kibana.", {"Ref": "HostedZoneName"} ]] },
-                        "Type" : "A",
-                        "AliasTarget" : {
-                           "HostedZoneId" : { "Fn::GetAtt" : ["ElkPublicLoadBalancer", "CanonicalHostedZoneNameID"] },
-                            "DNSName" : { "Fn::GetAtt" : ["ElkPublicLoadBalancer","DNSName"] }
-                        }
-                    },
-                    {
-                        "Name" : { "Fn::Join": ["", [ "logstash.", {"Ref": "HostedZoneName"} ]] },
-                        "Type" : "A",
-                        "AliasTarget" : {
-                           "HostedZoneId" : { "Fn::GetAtt" : ["ElkInternalLoadBalancer", "CanonicalHostedZoneNameID"] },
-                            "DNSName" : { "Fn::GetAtt" : ["ElkInternalLoadBalancer","DNSName"] }
-                        }
-                    }
-                ]
-            }
         }
     },
 
@@ -359,10 +338,6 @@
         "LogstashEndpoint": {
             "Value": { "Fn::Join": ["", [ { "Fn::GetAtt": [ "ElkInternalLoadBalancer", "DNSName" ]}, ":6379"]] },
             "Description": "Logging endpoint for Logstash TCP input"
-        },
-        "KibanaURL": {
-            "Value": { "Fn::Join": ["", ["http://", { "Fn::GetAtt": [ "ElkPublicLoadBalancer", "DNSName" ]}, "/#/dashboard/file/logstash.json"]] },
-            "Description": "URL for the Kibana Dashboard"
         },
         "GoogleOAuthRedirectUrl": {
             "Value": { "Fn::Join": ["", ["http://", { "Fn::GetAtt": [ "ElkPublicLoadBalancer", "DNSName" ]}, "/auth/google/callback"]] },

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC_Packer.json
@@ -70,6 +70,10 @@
         "HostedZoneName": {
             "Description": "Route53 Hosted Zone in which kibana aliases will be created",
             "Type": "String"
+        },
+        "PackerAMI": {
+            "Description": "The AMI produced by the elk.json packer build in github.com/guardian/elk-stack",
+            "Type": "String"
         }
     },
 
@@ -166,7 +170,7 @@
         "ElkLaunchConfig": {
             "Type": "AWS::AutoScaling::LaunchConfiguration",
             "Properties": {
-                "ImageId": "ami-cb4986bc",
+                "ImageId": { "Ref": "PackerAMI" },
                 "SecurityGroups": [ { "Ref": "ElkSecurityGroup" }, { "Ref": "ElkPublicLoadBalancerSecurityGroup" }, { "Ref": "ElkInternalLoadBalancerSecurityGroup" } ],
                 "InstanceType": { "Ref": "ElkInstanceType" },
                 "IamInstanceProfile": { "Ref": "InstanceProfile" },

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -307,7 +307,7 @@ indices.memory.index_buffer_size: 20%
 # operational within the cluster. Its recommended to set it to a higher value
 # than 1 when running more than 2 nodes in the cluster.
 #
-# discovery.zen.minimum_master_nodes: 1
+discovery.zen.minimum_master_nodes: @@MINIMUM_NODES
 
 # Set the time to wait for ping responses from other nodes when discovering.
 # Set this option to a higher value on a slow or congested network

--- a/config/housekeeping.sh
+++ b/config/housekeeping.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Cleanup indexes
+/usr/local/bin/curator --logformat logstash delete --older-than 7 | /bin/nc localhost 28778
+# Optimise older indexes
+/usr/local/bin/curator --logformat logstash bloom --older-than 1 | /bin/nc localhost 28778
+/usr/local/bin/curator --logformat logstash optimise --older-than 1 | /bin/nc localhost 28778

--- a/config/housekeeping.sh
+++ b/config/housekeeping.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Cleanup indexes
-/usr/local/bin/curator --logformat logstash delete --older-than 7 | /bin/nc localhost 28778
+/usr/local/bin/curator --logformat logstash delete --older-than 7 2>&1 | /bin/nc localhost 28778
 # Optimise older indexes
-/usr/local/bin/curator --logformat logstash bloom --older-than 1 | /bin/nc localhost 28778
-/usr/local/bin/curator --logformat logstash optimize --older-than 1 | /bin/nc localhost 28778
+/usr/local/bin/curator --logformat logstash bloom --older-than 1 2>&1 | /bin/nc localhost 28778
+/usr/local/bin/curator --logformat logstash optimize --older-than 1 2>&1 | /bin/nc localhost 28778

--- a/config/housekeeping.sh
+++ b/config/housekeeping.sh
@@ -3,4 +3,4 @@
 /usr/local/bin/curator --logformat logstash delete --older-than 7 | /bin/nc localhost 28778
 # Optimise older indexes
 /usr/local/bin/curator --logformat logstash bloom --older-than 1 | /bin/nc localhost 28778
-/usr/local/bin/curator --logformat logstash optimise --older-than 1 | /bin/nc localhost 28778
+/usr/local/bin/curator --logformat logstash optimize --older-than 1 | /bin/nc localhost 28778

--- a/config/logstash-indexer.conf
+++ b/config/logstash-indexer.conf
@@ -3,6 +3,15 @@ input {
         port  => 6379
         codec => json_lines
     }
+    tcp {
+        port      => 28778
+        codec     => json
+        add_field => {
+          "stack" => "editorial-tools-elk"
+          "app" => "curator"
+          "stage" => "INFRA"
+        }
+    }
 }
 
 output {

--- a/config/upstart-elasticsearch.conf
+++ b/config/upstart-elasticsearch.conf
@@ -14,7 +14,7 @@ limit nproc 4096 4096
 setuid elasticsearch
 setgid elasticsearch
 
-console output
+console log
 
 script
   ES_CONF_FILE=/etc/elasticsearch/elasticsearch.yml

--- a/config/upstart-elasticsearch.conf
+++ b/config/upstart-elasticsearch.conf
@@ -16,6 +16,13 @@ setgid elasticsearch
 
 console log
 
+pre-start script
+  if ! touch /data/test-permissions; then
+    echo "Could not write test file to /data"
+    stop; exit 0;
+  fi
+end script
+
 script
   ES_CONF_FILE=/etc/elasticsearch/elasticsearch.yml
 

--- a/packer/build.sh
+++ b/packer/build.sh
@@ -11,10 +11,10 @@ set -e
 # note that we don't actually use them in the script, the packer command does
 if [ -z "${AWS_ACCESS_KEY}" -o -z "${AWS_SECRET_KEY}" ]
 then
-  echo "AWS_ACCESS_KEY and AWS_SECRET_KEY environment variables must be set" > &2
+  echo "AWS_ACCESS_KEY and AWS_SECRET_KEY environment variables must be set" 1>&2
   exit 1
 fi
 
 # now build
-echo "Building ELK AMI"
+echo "Building ELK AMI" 1>&2
 ${PACKER_HOME}/packer build -color=false elk.json

--- a/packer/build.sh
+++ b/packer/build.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Build packer AMI (on TeamCity host)
+
+# die if any command fails
+set -e
+
+FLAGS='-color=false'
+# set DEBUG flag if not in TeamCity
+[ -z "${BUILD_NUMBER}" ] && FLAGS="-debug"
+
+# set PACKER_HOME if it isn't already provided
+[ -z "${PACKER_HOME}" ] && PACKER_HOME="/opt/packer"
+
+# set BUILD_NUMBER to DEV if not in TeamCity
+[ -z "${BUILD_NUMBER}" ] && BUILD_NUMBER="DEV"
+
+# set BUILD_BRANCH if not in TeamCity
+[ -z "${BUILD_BRANCH}" ] && BUILD_BRANCH="DEV"
+
+# set BUILD_NUMBER to DEV if not in TeamCity
+BUILD_NAME=${TEAMCITY_PROJECT_NAME}-${TEAMCITY_BUILDCONF_NAME}
+[ -z "${TEAMCITY_BUILDCONF_NAME}" -o -z "${TEAMCITY_PROJECT_NAME}" ] && BUILD_NAME="unknown"
+
+# ensure that we have AWS credentials (configure in TeamCity normally)
+# note that we don't actually use them in the script, the packer command does
+if [ -z "${AWS_ACCESS_KEY}" -o -z "${AWS_SECRET_KEY}" ]
+then
+  echo "AWS_ACCESS_KEY and AWS_SECRET_KEY environment variables must be set" 1>&2
+  exit 1
+fi
+
+# Get all the account numbers of our AWS accounts
+PRISM_JSON=$(curl -s "http://prism.gutools.co.uk/sources?resource=instance&origin.vendor=aws")
+ACCOUNT_NUMBERS=$(echo ${PRISM_JSON} | jq '.data[].origin.accountNumber' | tr '\n' ',' | sed s/\"//g | sed s/,$//)
+echo "Account numbers for AMI: $ACCOUNT_NUMBERS"
+
+# now build
+echo "Building ELK AMI" 1>&2
+${PACKER_HOME}/packer build $FLAGS \
+  -var "build_number=${BUILD_NUMBER}" -var "build_name=${BUILD_NAME}" \
+  -var "build_branch=${BUILD_BRANCH}" -var "account_numbers=${ACCOUNT_NUMBERS}" \
+  elk.json

--- a/packer/build.sh
+++ b/packer/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Build packer AMI (on TeamCity host)
+
+# die if any command fails
+set -e
+
+# set PACKER_HOME if it isn't already provided
+[ -z "${PACKER_HOME}" ] && PACKER_HOME=/opt/packer
+
+# ensure that we have AWS credentials (configure in TeamCity normally)
+if [ -z "${AWS_ACCESS_KEY}" -o -z "${AWS_SECRET_KEY}" ]
+then
+  echo "AWS_ACCESS_KEY and AWS_SECRET_KEY environment variables must be set" > &2
+  exit 1
+fi
+
+# now build
+echo "Building ELK AMI"
+${PACKER_HOME}/packer build -color=false elk.json

--- a/packer/build.sh
+++ b/packer/build.sh
@@ -8,6 +8,7 @@ set -e
 [ -z "${PACKER_HOME}" ] && PACKER_HOME=/opt/packer
 
 # ensure that we have AWS credentials (configure in TeamCity normally)
+# note that we don't actually use them in the script, the packer command does
 if [ -z "${AWS_ACCESS_KEY}" -o -z "${AWS_SECRET_KEY}" ]
 then
   echo "AWS_ACCESS_KEY and AWS_SECRET_KEY environment variables must be set" > &2

--- a/packer/elk-provisioning.sh
+++ b/packer/elk-provisioning.sh
@@ -13,7 +13,7 @@ apt-get --yes --force-yes install ruby ruby-dev
 apt-get --yes --force-yes install logstash elasticsearch nodejs
 
 ## Install Elasticsearch plugins
-/usr/share/elasticsearch/bin/plugin --install elasticsearch/elasticsearch-cloud-aws/2.1.1
+/usr/share/elasticsearch/bin/plugin --install elasticsearch/elasticsearch-cloud-aws/2.3.0
 /usr/share/elasticsearch/bin/plugin --install mobz/elasticsearch-head
 /usr/share/elasticsearch/bin/plugin --install lukas-vlcek/bigdesk
 /usr/share/elasticsearch/bin/plugin --install karmi/elasticsearch-paramedic

--- a/packer/elk-provisioning.sh
+++ b/packer/elk-provisioning.sh
@@ -1,18 +1,16 @@
 #!/bin/bash -x
 set -e
 ## Add repositories we are going to use
-add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu/ trusty universe multiverse"
-add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu/ trusty-updates universe multiverse"
-add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu/ trusty main restricted"
 add-apt-repository "deb http://packages.elasticsearch.org/logstash/1.4/debian stable main"
 add-apt-repository "deb http://packages.elasticsearch.org/elasticsearch/1.3/debian stable main"
 add-apt-repository -y ppa:chris-lea/node.js
 wget -O - https://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key add -
+sleep 1
 
 ## Update index and install packages
 apt-get update
-apt-get --yes --force-yes install git wget ruby ruby-dev make ec2-api-tools ec2-ami-tools
-apt-get --yes --force-yes install language-pack-en build-essential openjdk-7-jre-headless logstash elasticsearch nodejs
+apt-get --yes --force-yes install ruby ruby-dev
+apt-get --yes --force-yes install logstash elasticsearch nodejs
 
 ## Install Elasticsearch plugins
 /usr/share/elasticsearch/bin/plugin --install elasticsearch/elasticsearch-cloud-aws/2.1.1

--- a/packer/elk-provisioning.sh
+++ b/packer/elk-provisioning.sh
@@ -66,5 +66,5 @@ cp /tmp/config/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml.template
 cp /tmp/config/config.js /opt/logcabin/config.js.template
 
 ## Install upstart configuration
-cp /tmp/config/elasticsearch.conf /etc/init/elasticsearch.conf
-cp /tmp/config/logcabin.conf /etc/init/logcabin.conf
+cp /tmp/config/upstart-elasticsearch.conf /etc/init/elasticsearch.conf
+cp /tmp/config/upstart-logcabin.conf /etc/init/logcabin.conf

--- a/packer/elk-provisioning.sh
+++ b/packer/elk-provisioning.sh
@@ -44,9 +44,7 @@ echo "vm.overcommit_memory=1" > /etc/sysctl.d/70-vm-overcommit
 ## Install Kibana / Logcabin
 (
   cd /opt
-  wget -O elk-stack.tar.gz https://github.com/guardian/elk-stack/archive/master.tar.gz
-  tar zxvf elk-stack.tar.gz
-  mv elk-stack-master/src logcabin
+  cp -r /tmp/src /opt/logcabin
   adduser --disabled-password --gecos "" logcabin
   (
     cd logcabin

--- a/packer/elk-provisioning.sh
+++ b/packer/elk-provisioning.sh
@@ -21,6 +21,10 @@ apt-get --yes --force-yes install language-pack-en build-essential openjdk-7-jre
 /usr/share/elasticsearch/bin/plugin --install karmi/elasticsearch-paramedic
 /usr/share/elasticsearch/bin/plugin --install royrusso/elasticsearch-HQ
 
+## Install logstash config
+wget -O /etc/logstash/conf.d/logstash-indexer.conf https://raw.githubusercontent.com/guardian/elk-stack/master/config/logstash-indexer.conf
+sed -i -e 's,@@ELASTICSEARCH,localhost,g' /etc/logstash/conf.d/logstash-indexer.conf
+
 ## Mount the ephemeral storage on /data
 # Create /data
 mkdir /data
@@ -49,6 +53,8 @@ echo "vm.overcommit_memory=1" > /etc/sysctl.d/70-vm-overcommit
     npm install
   )
   chown -R logcabin logcabin
+  # TODO: Fix this ugly hack to convert this to https
+  sed -i s#http://#https://# /opt/logcabin/lib/google-oauth.js
 
   wget http://download.elasticsearch.org/kibana/kibana/kibana-latest.tar.gz
   tar zxvf kibana-latest.tar.gz

--- a/packer/elk-provisioning.sh
+++ b/packer/elk-provisioning.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -x
+## Add repositories we are going to use
+add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu/ trusty universe multiverse"
+add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu/ trusty-updates universe multiverse"
+add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu/ trusty main restricted"
+add-apt-repository "deb http://packages.elasticsearch.org/logstash/1.4/debian stable main"
+add-apt-repository "deb http://packages.elasticsearch.org/elasticsearch/1.3/debian stable main"
+add-apt-repository -y ppa:chris-lea/node.js
+wget -O - https://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key add -
+
+## Update index and install packages
+apt-get update
+apt-get --yes --force-yes install git wget ruby ruby-dev make ec2-api-tools ec2-ami-tools
+apt-get --yes --force-yes install language-pack-en build-essential openjdk-7-jre-headless logstash elasticsearch
+
+## Install Elasticsearch plugins
+/usr/share/elasticsearch/bin/plugin --install elasticsearch/elasticsearch-cloud-aws/2.1.1
+/usr/share/elasticsearch/bin/plugin --install mobz/elasticsearch-head
+/usr/share/elasticsearch/bin/plugin --install lukas-vlcek/bigdesk
+/usr/share/elasticsearch/bin/plugin --install karmi/elasticsearch-paramedic
+/usr/share/elasticsearch/bin/plugin --install royrusso/elasticsearch-HQ
+
+## Mount the ephemeral storage on /data
+# Create /data
+mkdir /data
+chown elasticsearch /data
+
+# Move volume from /mnt to /data
+umount /mnt
+sed -i s#/mnt#/data# /etc/fstab
+mount /data
+
+# Set permissions on actual volume
+chown elasticsearch /data
+
+## Ensure we don't swap unnecessarily
+sysctl vm.overcommit_memory=1
+
+## Install Kibana / Logcabin
+pushd /opt
+wget -O elk-stack.tar.gz https://github.com/guardian/elk-stack/archive/master.tar.gz
+tar zxvf elk-stack.tar.gz
+mv elk-stack-master/src logcabin
+adduser --disabled-password --gecos "" logcabin
+cd logcabin && npm install && cd ..
+chown -R logcabin logcabin
+
+wget http://download.elasticsearch.org/kibana/kibana/kibana-latest.tar.gz
+tar zxvf kibana-latest.tar.gz
+mv kibana-latest kibana
+popd
+
+## Download template config files (need to be configured in cloud-init)
+wget -O /etc/elasticsearch/elasticsearch.yml.template https://raw.githubusercontent.com/guardian/elk-stack/master/config/elasticsearch.yml
+wget -O /opt/logcabin/config.js.template https://raw.githubusercontent.com/guardian/elk-stack/master/config/config.js
+
+## Install upstart configuration
+wget -O /etc/init/elasticsearch.conf https://raw.githubusercontent.com/guardian/elk-stack/master/config/upstart-elasticsearch.conf
+wget -O /etc/init/logcabin.conf https://raw.githubusercontent.com/guardian/elk-stack/master/config/upstart-logcabin.conf

--- a/packer/elk-provisioning.sh
+++ b/packer/elk-provisioning.sh
@@ -22,7 +22,7 @@ apt-get --yes --force-yes install language-pack-en build-essential openjdk-7-jre
 /usr/share/elasticsearch/bin/plugin --install royrusso/elasticsearch-HQ
 
 ## Install logstash config
-wget -O /etc/logstash/conf.d/logstash-indexer.conf https://raw.githubusercontent.com/guardian/elk-stack/master/config/logstash-indexer.conf
+cp /tmp/config/logstash-indexer.conf /etc/logstash/conf.d/logstash-indexer.conf
 sed -i -e 's,@@ELASTICSEARCH,localhost,g' /etc/logstash/conf.d/logstash-indexer.conf
 
 ## Mount the ephemeral storage on /data
@@ -61,10 +61,10 @@ echo "vm.overcommit_memory=1" > /etc/sysctl.d/70-vm-overcommit
   mv kibana-latest kibana
 )
 
-## Download template config files (need to be configured in cloud-init)
-wget -O /etc/elasticsearch/elasticsearch.yml.template https://raw.githubusercontent.com/guardian/elk-stack/master/config/elasticsearch.yml
-wget -O /opt/logcabin/config.js.template https://raw.githubusercontent.com/guardian/elk-stack/master/config/config.js
+## Install the template config files (need to be configured in cloud-init at instance boot)
+cp /tmp/config/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml.template
+cp /tmp/config/config.js /opt/logcabin/config.js.template
 
 ## Install upstart configuration
-wget -O /etc/init/elasticsearch.conf https://raw.githubusercontent.com/guardian/elk-stack/master/config/upstart-elasticsearch.conf
-wget -O /etc/init/logcabin.conf https://raw.githubusercontent.com/guardian/elk-stack/master/config/upstart-logcabin.conf
+cp /tmp/config/elasticsearch.conf /etc/init/elasticsearch.conf
+cp /tmp/config/logcabin.conf /etc/init/logcabin.conf

--- a/packer/elk-provisioning.sh
+++ b/packer/elk-provisioning.sh
@@ -61,6 +61,10 @@ echo "vm.overcommit_memory=1" > /etc/sysctl.d/70-vm-overcommit
 cp /tmp/config/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml.template
 cp /tmp/config/config.js /opt/logcabin/config.js.template
 
+## Remove existing init.d config for elasticsearch
+rm /etc/init.d/elasticsearch
+update-rc.d elasticsearch remove
+
 ## Install upstart configuration
 cp /tmp/config/upstart-elasticsearch.conf /etc/init/elasticsearch.conf
 cp /tmp/config/upstart-logcabin.conf /etc/init/logcabin.conf

--- a/packer/elk-provisioning.sh
+++ b/packer/elk-provisioning.sh
@@ -9,8 +9,8 @@ sleep 1
 
 ## Update index and install packages
 apt-get update
-apt-get --yes --force-yes install ruby ruby-dev
-apt-get --yes --force-yes install logstash elasticsearch nodejs
+apt-get --yes --force-yes install ruby ruby-dev logstash elasticsearch \
+    nodejs python-pip
 
 ## Install Elasticsearch plugins
 /usr/share/elasticsearch/bin/plugin --install elasticsearch/elasticsearch-cloud-aws/2.3.0
@@ -22,6 +22,15 @@ apt-get --yes --force-yes install logstash elasticsearch nodejs
 ## Install logstash config
 cp /tmp/config/logstash-indexer.conf /etc/logstash/conf.d/logstash-indexer.conf
 sed -i -e 's,@@ELASTICSEARCH,localhost,g' /etc/logstash/conf.d/logstash-indexer.conf
+
+## Install the curator
+pip install elasticsearch-curator
+# Add script and install crontab
+mkdir -p /opt/bin
+cp /tmp/config/housekeeping.sh /opt/bin
+crontab -u elasticsearch - << EOM
+0 1 * * * /bin/bash /opt/bin/housekeeping.sh
+EOM
 
 ## Mount the ephemeral storage on /data
 # Create /data

--- a/packer/elk.json
+++ b/packer/elk.json
@@ -16,7 +16,8 @@
       "run_tags": {"Stage":"INFRA", "Stack":"packer", "App": "{{user `build_name`}}"},
       "ami_name": "elk-stack_{{user `build_number`}}_{{isotime \"2006-01-02\"}}",
       "ami_description": "AMI for ELK stack built by TeamCity: {{user `build_name`}}#{{user `build_number`}}",
-      "ami_users": "{{user `account_numbers`}}"
+      "ami_users": "{{user `account_numbers`}}",
+      "tags": {"Name": "{{user `build_name`}}", "Build":"{{user `build_number`}}"}
     }
   ],
 

--- a/packer/elk.json
+++ b/packer/elk.json
@@ -4,7 +4,7 @@
       "build_name": null,
       "account_numbers": "",
       "build_branch": "DEV",
-      "source_ami": "ami-3f38a848"
+      "source_ami": "ami-0345d674"
   },
   "builders": [
     {

--- a/packer/elk.json
+++ b/packer/elk.json
@@ -1,51 +1,36 @@
 {
   "variables": {
-      "account_id": "753338109777",
-      "s3_bucket": "workflow-amis",
       "build_number": "DEV",
       "build_name": null,
       "account_numbers": "",
-      "build_branch": "DEV"
+      "build_branch": "DEV",
+      "source_ami": "ami-274ecc50"
   },
   "builders": [
     {
       "type": "amazon-ebs",
       "region": "eu-west-1",
-      "source_ami": "ami-274ecc50",
+      "source_ami": "{{user `source_ami`}}",
       "instance_type": "m3.medium",
       "ssh_username": "ubuntu",
       "run_tags": {"Stage":"INFRA", "Stack":"packer", "App": "{{user `build_name`}}"},
       "ami_name": "elk-stack_{{user `build_number`}}_{{isotime \"2006-01-02\"}}",
       "ami_description": "AMI for ELK stack built by TeamCity: {{user `build_name`}}#{{user `build_number`}}",
       "ami_users": "{{user `account_numbers`}}",
-      "tags": {"Name": "{{user `build_name`}}", "Build":"{{user `build_number`}}", "Branch":"{{user `build_branch`}}"}
+      "tags": {
+        "Name": "{{user `build_name`}}",
+        "Build":"{{user `build_number`}}",
+        "Branch":"{{user `build_branch`}}",
+        "SourceAMI":"{{user `source_ami`}}"
+      }
     }
   ],
 
   "provisioners" : [
-    { "type": "shell",
-      "inline": [
-        "#!/bin/sh -x",
-        "sudo add-apt-repository \"deb http://us.archive.ubuntu.com/ubuntu/ trusty universe multiverse\"",
-        "sudo add-apt-repository \"deb http://us.archive.ubuntu.com/ubuntu/ trusty-updates universe multiverse\"",
-        "sudo add-apt-repository \"deb http://us.archive.ubuntu.com/ubuntu/ trusty main restricted\"",
-        "sudo add-apt-repository \"deb http://packages.elasticsearch.org/logstash/1.4/debian stable main\"",
-        "sudo add-apt-repository \"deb http://packages.elasticsearch.org/elasticsearch/1.3/debian stable main\"",
-        "sudo add-apt-repository -y ppa:chris-lea/node.js",
-        "echo \"wget -O - http://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key add -\" | sudo sh",
-        "sudo apt-get update",
-        "sudo apt-get --yes --force-yes install git wget ruby ruby-dev make ec2-api-tools ec2-ami-tools",
-        "sudo apt-get --yes --force-yes install language-pack-en build-essential openjdk-7-jre-headless logstash elasticsearch ",
-        "sudo /usr/share/elasticsearch/bin/plugin --install elasticsearch/elasticsearch-cloud-aws/2.1.1",
-        "sudo /usr/share/elasticsearch/bin/plugin --install mobz/elasticsearch-head",
-        "sudo /usr/share/elasticsearch/bin/plugin --install lukas-vlcek/bigdesk",
-        "sudo /usr/share/elasticsearch/bin/plugin --install karmi/elasticsearch-paramedic",
-        "sudo /usr/share/elasticsearch/bin/plugin --install royrusso/elasticsearch-HQ",
-        "sudo mkdir /data",
-        "sudo mount /dev/xvdb /data",
-        "sudo chown elasticsearch /data",
-        "sudo sysctl vm.overcommit_memory=1"
-        ]
+    {
+      "type": "shell",
+      "script": "elk-provisioning.sh",
+      "execute_command": "{{ .Vars }} sudo -E bash -x '{{ .Path }}'"
     }
   ]
 }

--- a/packer/elk.json
+++ b/packer/elk.json
@@ -1,7 +1,10 @@
 {
   "variables": {
       "account_id": "753338109777",
-      "s3_bucket": "workflow-amis"
+      "s3_bucket": "workflow-amis",
+      "build_number": "DEV",
+      "build_name": null,
+      "account_numbers": ""
   },
   "builders": [
     {
@@ -10,8 +13,10 @@
       "source_ami": "ami-274ecc50",
       "instance_type": "m3.medium",
       "ssh_username": "ubuntu",
-      "ami_name": "elk-base_{{isotime \"2006-01-02\"}}",
-      "ami_users": ["753338109777", "743583969668"]
+      "run_tags": {"Stage":"INFRA", "Stack":"packer", "App": "{{user `build_name`}}"},
+      "ami_name": "elk-stack_{{user `build_number`}}_{{isotime \"2006-01-02\"}}",
+      "ami_description": "AMI for ELK stack built by TeamCity: {{user `build_name`}}#{{user `build_number`}}",
+      "ami_users": "{{user `account_numbers`}}"
     }
   ],
 

--- a/packer/elk.json
+++ b/packer/elk.json
@@ -33,6 +33,11 @@
       "destination": "/tmp"
     },
     {
+      "type": "file",
+      "source": "../src",
+      "destination": "/tmp"
+    },
+    {
       "type": "shell",
       "script": "elk-provisioning.sh",
       "execute_command": "{{ .Vars }} sudo -E bash -x '{{ .Path }}'"

--- a/packer/elk.json
+++ b/packer/elk.json
@@ -4,7 +4,8 @@
       "s3_bucket": "workflow-amis",
       "build_number": "DEV",
       "build_name": null,
-      "account_numbers": ""
+      "account_numbers": "",
+      "build_branch": "DEV"
   },
   "builders": [
     {
@@ -17,7 +18,7 @@
       "ami_name": "elk-stack_{{user `build_number`}}_{{isotime \"2006-01-02\"}}",
       "ami_description": "AMI for ELK stack built by TeamCity: {{user `build_name`}}#{{user `build_number`}}",
       "ami_users": "{{user `account_numbers`}}",
-      "tags": {"Name": "{{user `build_name`}}", "Build":"{{user `build_number`}}"}
+      "tags": {"Name": "{{user `build_name`}}", "Build":"{{user `build_number`}}", "Branch":"{{user `build_branch`}}"}
     }
   ],
 

--- a/packer/elk.json
+++ b/packer/elk.json
@@ -28,6 +28,11 @@
 
   "provisioners" : [
     {
+      "type": "file",
+      "source": "../config",
+      "destination": "/tmp"
+    },
+    {
       "type": "shell",
       "script": "elk-provisioning.sh",
       "execute_command": "{{ .Vars }} sudo -E bash -x '{{ .Path }}'"

--- a/packer/elk.json
+++ b/packer/elk.json
@@ -4,7 +4,7 @@
       "build_name": null,
       "account_numbers": "",
       "build_branch": "DEV",
-      "source_ami": "ami-274ecc50"
+      "source_ami": "ami-3f38a848"
   },
   "builders": [
     {

--- a/packer/elk.json
+++ b/packer/elk.json
@@ -1,0 +1,47 @@
+{
+  "variables": {
+      "aws_access_key": "{{env `AWS_ACCESS_KEY`}}",
+      "aws_secret_key": "{{env `AWS_SECRET_KEY`}}",
+      "account_id": "753338109777",
+      "s3_bucket": "workflow-amis"
+  },
+  "builders": [
+    { 
+      "type": "amazon-ebs",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "region": "eu-west-1",
+      "source_ami": "ami-274ecc50",
+      "instance_type": "m3.medium",
+      "ssh_username": "ubuntu",
+      "ami_name": "elk-base_{{isotime \"2006-01-02\"}}"
+    }
+  ],
+
+  "provisioners" : [
+    { "type": "shell",
+      "inline": [
+        "#!/bin/sh -x",
+        "sudo add-apt-repository \"deb http://us.archive.ubuntu.com/ubuntu/ trusty universe multiverse\"",
+        "sudo add-apt-repository \"deb http://us.archive.ubuntu.com/ubuntu/ trusty-updates universe multiverse\"",
+        "sudo add-apt-repository \"deb http://us.archive.ubuntu.com/ubuntu/ trusty main restricted\"",
+        "sudo add-apt-repository \"deb http://packages.elasticsearch.org/logstash/1.4/debian stable main\"",
+        "sudo add-apt-repository \"deb http://packages.elasticsearch.org/elasticsearch/1.3/debian stable main\"",
+        "sudo add-apt-repository -y ppa:chris-lea/node.js",
+        "echo \"wget -O - http://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key add -\" | sudo sh",
+        "sudo apt-get update",
+        "sudo apt-get --yes --force-yes install git wget ruby ruby-dev make ec2-api-tools ec2-ami-tools",
+        "sudo apt-get --yes --force-yes install language-pack-en build-essential openjdk-7-jre-headless logstash elasticsearch ",
+        "sudo /usr/share/elasticsearch/bin/plugin --install elasticsearch/elasticsearch-cloud-aws/2.1.1",
+        "sudo /usr/share/elasticsearch/bin/plugin --install mobz/elasticsearch-head",
+        "sudo /usr/share/elasticsearch/bin/plugin --install lukas-vlcek/bigdesk",
+        "sudo /usr/share/elasticsearch/bin/plugin --install karmi/elasticsearch-paramedic",
+        "sudo /usr/share/elasticsearch/bin/plugin --install royrusso/elasticsearch-HQ",
+        "sudo mkdir /data",
+        "sudo mount /dev/xvdb /data",
+        "sudo chown elasticsearch /data",
+        "sudo sysctl vm.overcommit_memory=1"
+        ]
+    }
+  ]
+}

--- a/packer/elk.json
+++ b/packer/elk.json
@@ -1,20 +1,17 @@
 {
   "variables": {
-      "aws_access_key": "{{env `AWS_ACCESS_KEY`}}",
-      "aws_secret_key": "{{env `AWS_SECRET_KEY`}}",
       "account_id": "753338109777",
       "s3_bucket": "workflow-amis"
   },
   "builders": [
-    { 
+    {
       "type": "amazon-ebs",
-      "access_key": "{{user `aws_access_key`}}",
-      "secret_key": "{{user `aws_secret_key`}}",
       "region": "eu-west-1",
       "source_ami": "ami-274ecc50",
       "instance_type": "m3.medium",
       "ssh_username": "ubuntu",
-      "ami_name": "elk-base_{{isotime \"2006-01-02\"}}"
+      "ami_name": "elk-base_{{isotime \"2006-01-02\"}}",
+      "ami_users": ["753338109777", "743583969668"]
     }
   ],
 

--- a/src/lib/google-oauth.js
+++ b/src/lib/google-oauth.js
@@ -22,6 +22,7 @@ exports.setupOAuth = function(express, app, config) {
             clientID: config.oauth_client_id,
             clientSecret: config.oauth_client_secret,
             callbackURL: callbackUrl
+            hostedDomain: config.allowed_domain
         }, function(accessToken, refreshToken, profile, done) {
             findUser(profile, accessToken, config, function(succeed, msg) {
                 return succeed ? done(null, profile): done(null, false, { message: msg})
@@ -68,11 +69,5 @@ function nonAuthenticated(config, url) {
 
 function findUser(profile, accessToken, config, callback)  {
     var username = profile.displayName || 'unknown'
-
-    if (profile._json.email.split('@')[1] === config.allowed_domain) {
-        return callback(true, username)
-    } else {
-        console.log('access refused to: ' + username)
-        return callback(false, username + ' is not authorized')
-    }
+    return callback(true, username)
 }

--- a/src/lib/google-oauth.js
+++ b/src/lib/google-oauth.js
@@ -21,7 +21,7 @@ exports.setupOAuth = function(express, app, config) {
     passport.use(new GoogleStrategy({
             clientID: config.oauth_client_id,
             clientSecret: config.oauth_client_secret,
-            callbackURL: callbackUrl
+            callbackURL: callbackUrl,
             hostedDomain: config.allowed_domain
         }, function(accessToken, refreshToken, profile, done) {
             findUser(profile, accessToken, config, function(succeed, msg) {


### PR DESCRIPTION
This PR adds a packer template for building an AWS AMI that runs the ELK stack. It also adds a TeamCity script that runs packer.

Some nice things we do:
 - Add tags to each AMI with the project name, build number and branch name
 - Look up all the AWS accounts that we know of and allow all of those accounts to use the resulting AMI

 - [x] A cloud formation template that can be used to bring up an ELK stack based on this AMI