### PR TITLE
Add cluster health to list of unauthenticated endpoints

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -2,7 +2,7 @@ module.exports =  {
     'host': '@@LOGCABIN_HOST',
     'listen_port': 8080,
     'cookie_secret': '@@COOKIE_SECRET',
-    'oauth_unauthenticated': ['/__es/'],
+    'oauth_unauthenticated': ['/__es/', '/__es/_cat/health'],
     // 'oauth_application_name': 'logcabin',
     'oauth_client_id': '@@CLIENT_ID',
     'oauth_client_secret': '@@CLIENT_SECRET',


### PR DESCRIPTION
Should be able to use cluster health endpoint as remote healthcheck URL by looking for `green` in the following output:
```
$ curl 'http://kibana.example.com/__es/_cat/health'
1424866679 12:17:59 logger green 3 3 96 48 0 0 0
```