### PR TITLE
Parameterise IP ranges for optionally enhanced security

### DIFF
--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
@@ -73,6 +73,16 @@
             "Description": "Subnets to use in VPC for instances eg. subnet-abcd1234",
             "Type": "List<AWS::EC2::Subnet::Id>"
         },
+        "VpcIpRangeCidr" : {
+            "Description": "VPC IP range eg. 10.0.0.0/8",
+            "Type": "String",
+            "Default": "0.0.0.0/0"
+        },
+        "AllowedSshCidr" : {
+            "Description": "IP range to allow SSH access from eg. 1.2.3.4/21",
+            "Type": "String",
+            "Default": "0.0.0.0/0"
+        },
         "HostedZoneName": {
             "Description": "Route53 Hosted Zone in which kibana aliases will be created (without the trailing dot). Leave blank for no ALIAS.",
             "Type": "String",
@@ -480,7 +490,7 @@
                         "IpProtocol": "tcp",
                         "FromPort": "6379",
                         "ToPort": "6379",
-                        "CidrIp": "0.0.0.0/0"
+                        "CidrIp": { "Ref": "VpcIpRangeCidr" }
                     }
                 ],
                 "SecurityGroupEgress": [
@@ -488,7 +498,7 @@
                         "IpProtocol": "tcp",
                         "FromPort": "6379",
                         "ToPort": "6379",
-                        "CidrIp": "0.0.0.0/0"
+                        "CidrIp": { "Ref": "VpcIpRangeCidr" }
                     }
                 ]
             }
@@ -516,7 +526,7 @@
                         "IpProtocol": "tcp",
                         "FromPort": "22",
                         "ToPort": "22",
-                        "CidrIp": "0.0.0.0/0"
+                        "CidrIp": { "Ref": "AllowedSshCidr" }
                     }
                 ]
             }


### PR DESCRIPTION
We are looking to lock down the SSH and Elastic Search ports to specific IP ranges, but without forking off the existing CloudFormation template or suggesting an obtrusive change.

This PR adds two optional parameters when configuring the stack:

- `VpcIpRangeCidr`, the IP range of the VPC. This is used for the Elastic Search security group to determine access to port 6379
- `AllowedSshCidr `, an IP range allowed to SSH into the instances in the stack on port 22

By default these two parameters will default to `0.0.0.0/0`, which is the equivalent of what is already hard coded in the template.

Anyone already using this stack already can safely use those defaults and anyone who wishes to reconfigure our set up a new stack can opt in for those additional security restrictions.