### PR TITLE
Update AMI image to Ubuntu 15.10 Wily

### DIFF
--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
@@ -114,15 +114,15 @@
 
     "Mappings" : {
         "RegionMap" : {
-            "us-east-1" :      { "ImageId": "ami-41986a2a" },
-            "us-west-2" :      { "ImageId": "ami-35d4ee05" },
-            "us-west-1" :      { "ImageId": "ami-5915e11d" },
-            "eu-west-1" :      { "ImageId": "ami-b7443fc0" },
-            "eu-central-1" :   { "ImageId": "ami-1afbc307" },
-            "ap-southeast-1" : { "ImageId": "ami-205c5872" },
-            "ap-southeast-2" : { "ImageId": "ami-990a70a3" },
-            "ap-northeast-1" : { "ImageId": "ami-ee72a8ee" },
-            "sa-east-1" :      { "ImageId": "ami-7727a46a" }
+            "us-east-1" :      { "ImageId": "ami-8d4071e7" },
+            "us-west-2" :      { "ImageId": "ami-4b37d42b" },
+            "us-west-1" :      { "ImageId": "ami-bcafdedc" },
+            "eu-west-1" :      { "ImageId": "ami-36289a45" },
+            "eu-central-1" :   { "ImageId": "ami-30677d5c" },
+            "ap-southeast-1" : { "ImageId": "ami-af965fcc" },
+            "ap-northeast-1" : { "ImageId": "ami-552a2b3b" },
+            "ap-southeast-2" : { "ImageId": "ami-5195b232" },
+            "sa-east-1" :      { "ImageId": "ami-df0586b3" }
         },
         "InstanceMap": {
             "t2.medium":  { "ESHeapSize": "2g" },

--- a/scripts/get_ami_images.sh
+++ b/scripts/get_ami_images.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-AMI_IMAGE_NAME="ubuntu/images/hvm/ubuntu-vivid-15.04-amd64-server-20150616.1"
+AMI_IMAGE_NAME="ubuntu/images/hvm-ssd/ubuntu-wily-15.10-amd64-server-20160217.1"
 
 # http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region
 
-for region in us-east-1 us-west-2 us-west-1 eu-west-1 eu-central-1 ap-southeast-1 ap-southeast-2 ap-northeast-1 sa-east-1
+for region in us-east-1 us-west-2 us-west-1 eu-west-1 eu-central-1 ap-southeast-1 ap-northeast-1 ap-southeast-2 ap-northeast-2 sa-east-1
 do
     printf "\"$region\" : {"
     aws ec2 describe-images --filters Name=name,Values=$AMI_IMAGE_NAME --region $region | grep "ImageId" | sed s/,// | tr -d '\n'


### PR DESCRIPTION
Use patched AMI image for Ubuntu because of [this](https://googleonlinesecurity.blogspot.co.uk/2016/02/cve-2015-7547-glibc-getaddrinfo-stack.html) security vulnerability.