### PR TITLE
Update to Kibana 4.4, Elasticsearch 2.x and Logstash 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 ELK Stack with Google OAuth
 ===========================
 
-ELK stands for [Elasticsearch][1], [Logstash][2] and [Kibana 4][3] and is being promoted by Elasticsearch as a "devops" logging solution.
+ELK stands for [Elasticsearch 2][1], [Logstash 2][2] and [Kibana 4][3] and is being promoted by Elasticsearch as a "devops" logging solution.
 
 This implemenation of an ELK stack is designed to run in AWS EC2 VPC and is secured using Google OAuth 2.0. It consists of one or more instances behind an Elastic Load Balancer (ELB) running the following components:
 
-* Kibana 4
-* Elasticsearch
-* Logstash indexer
+* Kibana 4.x
+* Elasticsearch 2.x
+* Logstash 2.x indexer
 * Node.js application proxy
 
 Security
@@ -62,12 +62,10 @@ The following elasticsearch plugins are installed:
 
   * [AWS Cloud plugin][8] - uses AWS API for the unicast discovery mechanism
   * [elasticsearch-head][9] - web frontend for elasticsearch cluster
-  * [ElasticSearch Paramedic][10] - a simple tool to inspect the state and statistics about ElasticSearch clusters
 
-The "head" and "paramedic" web pages are available at proxied (ie. authenticated) endpoints based on how the ELK stack is deployed:
+The "head" plugin web page is available at proxied (ie. authenticated) endpoints based on how the ELK stack is deployed:
 
   * Head      -> `http://<ELB>/__es/_plugin/head/`
-  * Paramedic -> `http://<ELB>/__es/_plugin/paramedic/`
 
 Configuration
 -------------
@@ -82,7 +80,7 @@ License
 -------
 
     Guardian ELK Stack Cloudformation Templates and Logcabin Proxy
-    Copyright 2015 Guardian News & Media
+    Copyright 2014-2016 Guardian News & Media
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -103,6 +101,6 @@ License
 [5]: <https://console.developers.google.com> "Google Developer Console"
 [6]: <http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Subnets.html> "AWS: Your VPC and Subnets"
 [7]: <https://console.aws.amazon.com/vpc/>
-[8]: <https://github.com/elastic/elasticsearch-cloud-aws>
+[8]: <https://github.com/elastic/elasticsearch/tree/2.0/plugins/cloud-aws>
 [9]: <http://mobz.github.io/elasticsearch-head/>
-[10]: <https://github.com/karmi/elasticsearch-paramedic>
+

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
@@ -361,6 +361,12 @@
                                 " >> /etc/default/elasticsearch"
                             ] ] },
 
+                            "cat >/etc/security/limits.conf << EOF",
+                            "# allow user 'elasticsearch' mlockall",
+                            "elasticsearch soft memlock unlimited",
+                            "elasticsearch hard memlock unlimited",
+                            "EOF",
+
                             "echo \"vm.overcommit_memory=1\" >> /usr/lib/sysctl.d/elasticsearch.conf",
 
                             { "Fn::If": [
@@ -538,7 +544,7 @@
                 "GroupId": { "Fn::GetAtt": [ "ElkSecurityGroup", "GroupId" ] },
                 "IpProtocol": "tcp",
                 "FromPort": "9300",
-                "ToPort": "9305",
+                "ToPort": "9400",
                 "SourceSecurityGroupId": { "Fn::GetAtt": [ "ElkSecurityGroup", "GroupId" ] }
             }
         },

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
@@ -385,7 +385,6 @@
                             "chown elasticsearch /data",
 
                             "wget -O /etc/logstash/conf.d/logstash-indexer.conf https://raw.githubusercontent.com/guardian/elk-stack/master/config/logstash-indexer.conf",
-                            "sed -i -e 's,@@ELASTICSEARCH,localhost,g' /etc/logstash/conf.d/logstash-indexer.conf",
 
                             "# Install Kibana",
 

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
@@ -335,19 +335,19 @@
                             "# Update repositories",
 
                             "wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -",
-                            "echo \"deb http://packages.elastic.co/elasticsearch/1.6/debian stable main\" > /etc/apt/sources.list.d/elasticsearch.list",
-                            "echo \"deb http://packages.elastic.co/logstash/1.5/debian stable main\" > /etc/apt/sources.list.d/logstash.list",
-                            "add-apt-repository -y ppa:chris-lea/node.js",
+                            "echo \"deb http://packages.elastic.co/elasticsearch/2.x/debian stable main\" > /etc/apt/sources.list.d/elasticsearch-2.x.list",
+                            "echo \"deb http://packages.elastic.co/logstash/2.2/debian stable main\" > /etc/apt/sources.list.d/logstash-2.x.list",
+                            "curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash -",
                             "sleep 1",
                             "apt-get -y update",
 
                             "# Install Logstash & Elasticsearch",
 
-                            "apt-get -y install ruby ruby-dev logstash openjdk-8-jre-headless openjdk-8-jdk elasticsearch nodejs ntp npm python-pip",
+                            "apt-get -y install ruby ruby-dev logstash openjdk-8-jre-headless openjdk-8-jdk elasticsearch nodejs ntp python-pip",
+                            "update-ca-certificates -f",
 
-                            "/usr/share/elasticsearch/bin/plugin --install elasticsearch/elasticsearch-cloud-aws/2.6.0",
-                            "/usr/share/elasticsearch/bin/plugin --install mobz/elasticsearch-head",
-                            "/usr/share/elasticsearch/bin/plugin --install karmi/elasticsearch-paramedic",
+                            "/usr/share/elasticsearch/bin/plugin install cloud-aws -b",
+                            "/usr/share/elasticsearch/bin/plugin install mobz/elasticsearch-head",
 
                             "wget -O /etc/elasticsearch/elasticsearch.yml https://raw.githubusercontent.com/guardian/elk-stack/master/config/elasticsearch.yml",
                             { "Fn::Join": [ "", [ "sed -i",
@@ -383,7 +383,7 @@
 
                             "# Install Kibana",
 
-                            "wget -O /tmp/kibana-latest.tar.gz https://download.elastic.co/kibana/kibana/kibana-4.1.0-linux-x64.tar.gz",
+                            "wget -O /tmp/kibana-latest.tar.gz https://download.elastic.co/kibana/kibana/kibana-4.4.1-linux-x64.tar.gz",
                             "tar zxf /tmp/kibana-latest.tar.gz -C /opt",
                             "mv /opt/kibana-* /opt/kibana",
 

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -233,8 +233,8 @@ bootstrap.mlockall: true
 #
 # http.enabled: false
 
-http.host: 127.0.0.1
-
+http.host: _local_
+network.host: _ec2_
 
 ################################### Gateway ###################################
 

--- a/config/logstash-indexer.conf
+++ b/config/logstash-indexer.conf
@@ -6,10 +6,6 @@ input {
 }
 
 output {
-    # stdout { }
-
-    elasticsearch {
-        protocol => "http"
-        host     => "@@ELASTICSEARCH"
-    }
+    elasticsearch { hosts => ["localhost:9200"] }
+    # stdout { codec => rubydebug }
 }


### PR DESCRIPTION
WARNING: Migrating to Elasticsearch 2.x requires a [FULL CLUSTER RESTART](https://www.elastic.co/guide/en/elasticsearch/reference/current/restart-upgrade.html).

Alternatively export your dashboards, delete your existing 1.x stack, update and deploy this 2.x stack and then import your dashboards back. You will **LOSE ALL YOUR DATA** but it's only log files, right :-)