### PR TITLE
Force Curator version to 3.5.1

### DIFF
--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
@@ -567,7 +567,7 @@
                             ]},
                             "# Setup schedule to delete old indexes",
 
-                            "pip install elasticsearch-curator",
+                            "pip install elasticsearch-curator==3.5.1",
                             { "Fn::Join": [ "", [
                                 "echo '30 0 * * * root /usr/local/bin/curator --logfile /var/log/elasticsearch/curator.log delete indices --older-than ",
                                 { "Ref" : "IndexKeepDays" },


### PR DESCRIPTION
Not specifying the version leads to install the most up to date version
of Curator. However Curator 4 has been released and it is NOT backward
compatible.
This patch forces installing Curator 3.5.1.

@satterly 