### PR TITLE
Add the possibility to setup public ELB to be accessed via HTTPS

### DIFF
--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.json
@@ -113,13 +113,18 @@
             "Description": "Keep elasticsearch indices for x number of days",
             "Type": "Number",
             "Default": "8"
+        },
+        "PublicLoadBalancerSSLCertificateARN": {
+            "Description": "ARN of the SSL certificate applied to the public load balancer",
+            "Type": "String"
         }
     },
 
     "Conditions": {
         "HasDNS": { "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "HostedZoneName" }, "" ] } ] },
         "UseEBS": { "Fn::Not": [ { "Fn::Equals" : [ { "Ref" : "EBSVolumeSize" }, "0" ] } ]},
-        "HasS3": { "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "SnapshotRepository" }, "" ] } ] }
+        "HasS3": { "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "SnapshotRepository" }, "" ] } ] },
+        "HasSSLCertificate": { "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "PublicLoadBalancerSSLCertificateARN" }, "" ] } ] }
     },
 
     "Mappings" : {
@@ -339,9 +344,11 @@
                 "CrossZone": true,
                 "Listeners": [
                     {
-                        "Protocol": "HTTP",
-                        "LoadBalancerPort": "80",
-                        "InstancePort": "8080"
+                        "Protocol": { "Fn::If" : [ "HasSSLCertificate", "HTTPS", "HTTP" ] },
+                        "LoadBalancerPort": { "Fn::If" : [ "HasSSLCertificate", "443", "80" ] },
+                        "InstanceProtocol": "HTTP",
+                        "InstancePort": "8080",
+                        "SSLCertificateId": { "Ref": "PublicLoadBalancerSSLCertificateARN" }
                     }
                 ],
                 "HealthCheck": {
@@ -528,9 +535,12 @@
                             "wget -O /opt/logcabin/config.js https://raw.githubusercontent.com/guardian/elk-stack/master/config/config.js",
                             { "Fn::Join": [ "", [ "sed -i",
                                 " -e s,@@LOGCABIN_HOST,",
-                                    { "Fn::If" : [ "HasDNS",
-                                        { "Fn::Join": [".", [ "kibana", {"Ref": "HostedZoneName"} ]] },
-                                        { "Fn::GetAtt": [ "ElkPublicLoadBalancer", "DNSName" ] }
+                                    { "Fn::Join": ["", 
+                                        [{ "Fn::If" : [ "HasSSLCertificate", "https://", "http://" ] },
+                                        { "Fn::If" : [ "HasDNS",
+                                            { "Fn::Join": [".", [ "kibana", {"Ref": "HostedZoneName"} ]] },
+                                            { "Fn::GetAtt": [ "ElkPublicLoadBalancer", "DNSName" ]}
+                                        ]}]
                                     ]}, ",g",
                                 " -e s,@@API_KEY,", { "Ref": "ApiKey" }, ",g",
                                 " -e s,@@COOKIE_SECRET,", { "Ref": "CookieSecret" }, ",g",
@@ -707,7 +717,7 @@
             "Description": "Logging endpoint for Logstash TCP input"
         },
         "KibanaURL": {
-            "Value": { "Fn::Join": ["", ["http://",
+            "Value": { "Fn::Join": ["", [ { "Fn::If" : [ "HasSSLCertificate", "https://", "http://" ] },
                 { "Fn::If" : [ "HasDNS",
                     { "Fn::Join": [".", [ "kibana", {"Ref": "HostedZoneName"} ]] },
                     { "Fn::GetAtt": [ "ElkPublicLoadBalancer", "DNSName" ]}
@@ -715,7 +725,7 @@
             "Description": "URL for the Kibana 4 Dashboard"
         },
         "GoogleOAuthRedirectUrl": {
-            "Value": { "Fn::Join": ["", ["http://",
+            "Value": { "Fn::Join": ["", [ { "Fn::If" : [ "HasSSLCertificate", "https://", "http://" ] },
                 { "Fn::If" : [ "HasDNS",
                     { "Fn::Join": [".", [ "kibana", {"Ref": "HostedZoneName"} ]] },
                     { "Fn::GetAtt": [ "ElkPublicLoadBalancer", "DNSName" ]}

--- a/src/config.js.example
+++ b/src/config.js.example
@@ -1,5 +1,5 @@
 module.exports =  {
-    'host': 'localhost:9201',
+    'host': 'http://localhost:9201',
     'listen_port': 9201,
     'apiKeys': ['YOUR_API_KEY'],
     'cookie_secret': 'DAX52Zo15CWfBUnoyp4rjY',
@@ -7,8 +7,6 @@ module.exports =  {
     'oauth_application_name': 'logcabin-local',
     'oauth_client_id': '968588183953-v3767ro0sr1parm613pmsujgrupapo3a.apps.googleusercontent.com',
     'oauth_client_secret': 'z6t0aUbgrnIp3Ot4DtjMTB2A',
-    // 'oauth_client_id': 'fd1e58de5907553c00ca',
-    // 'oauth_client_secret': '6c10760f16b40dd161268be0ed04eafaa6e1614d',
     'allowed_domain': 'guardian.co.uk',
     'es_host': 'localhost',
     'es_port': 9200

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -16,7 +16,7 @@ exports.setup = function(express, app, config) {
       done(null, obj)
     })
 
-    var callbackUrl = 'http://' + config.host + '/auth/google/callback'
+    var callbackUrl = config.host + '/auth/google/callback'
 
     passport.use(new GoogleStrategy({
             clientID: config.oauth_client_id,


### PR DESCRIPTION
This patch adds a CFN template parameter for the SSL certificate ARN
If one is specified, the public ELB will be configured to accept
requests via https on port 443

@satterly 