### PR TITLE
Remove new line from s3 snapshot setup

### DIFF
--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.yml
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.yml
@@ -468,8 +468,7 @@ Resources:
           SetupS3Snapshot: !If
             - HasS3
             - !Sub |
-                while ! nc -z localhost 9200; do sleep 5; done; echo Elasticsearch
-                  is up!
+                while ! nc -z localhost 9200; do sleep 5; done; echo Elasticsearch is up!
                 curl -XPUT 'http://localhost:9200/_snapshot/s3' -d '{ \
                   "type": "s3", \
                   "settings": { \


### PR DESCRIPTION
Removes unintentional newline which causes the following error on instance start up (if s3 snapshot configured).

    /var/lib/cloud/instance/scripts/part-001: line 93: is: command not found