### PR TITLE
make the policy managed, encrypt the EBS

### DIFF
--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.yml
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.yml
@@ -213,10 +213,10 @@ Resources:
     Type: AWS::Kinesis::Stream
     Properties:
       ShardCount: '1'
-  ElkKinesisPublisherPolicy:
-    Type: AWS::IAM::Policy
+  ElkKinesisPublisherPolicy2:
+    Type: AWS::IAM::ManagedPolicy
     Properties:
-      PolicyName: elk-kinesis-publisher
+      Description: "Policy for allowing writes to the kinesis logging stream"
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -347,6 +347,7 @@ Resources:
           Ebs:
             VolumeSize: !Ref EBSVolumeSize
             VolumeType: gp2
+            Encrypted: true
         - !Ref AWS::NoValue
       IamInstanceProfile: !Ref InstanceProfile
       KeyName: !Ref KeyName


### PR DESCRIPTION
I've been installing this for the subs team, and we really need to encrypt our logs due to PII risk.
I also need to reference the kinesis writer policy so I can attach it to my instances' role.

Not sure if these are changes that should apply to everyone, but they could be parameterised if necessary.

@adamnfish @jfsoul @TBonnin you guys have been PRing this project recently so you can critique my PR 😛 