### PR TITLE
Remove trailing comma to fix snapshots

### DIFF
--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.yml
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.yml
@@ -473,7 +473,7 @@ Resources:
                   "type": "s3", \
                   "settings": { \
                     "bucket": "${ElkS3Bucket}", \
-                    "region": "${AWS::Region}", \
+                    "region": "${AWS::Region}" \
                   } \
                 }'
                 curl 'http://localhost:9200/_snapshot/s3?pretty'


### PR DESCRIPTION
Snapshot configuration for elasticsearch appears to be broken because the JSON can't be parsed. Trailing comma is the culprit.