### PR TITLE
Allow server side encryption of snapshots

### DIFF
--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.yml
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.yml
@@ -474,13 +474,13 @@ Resources:
             - HasS3
             - !Sub |
                 while ! nc -z localhost 9200; do sleep 5; done; echo Elasticsearch is up!
-                curl -XPUT 'http://localhost:9200/_snapshot/s3' -d '{ \
-                  "type": "s3", \
-                  "settings": { \
-                    "bucket": "${ElkS3Bucket}", \
-                    "region": "${AWS::Region}", \
-                    "server_side_encryption": "${SnapshotRepositoryEncryption}" \
-                  } \
+                curl -XPUT 'http://localhost:9200/_snapshot/s3' -d '{
+                  "type": "s3",
+                  "settings": {
+                    "bucket": "${ElkS3Bucket}",
+                    "region": "${AWS::Region}",
+                    "server_side_encryption": "${SnapshotRepositoryEncryption}"
+                  }
                 }'
                 curl 'http://localhost:9200/_snapshot/s3?pretty'
                 wget -O /usr/local/bin/backup.sh https://raw.githubusercontent.com/guardian/elk-stack/master/scripts/backup.sh

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.yml
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.yml
@@ -93,6 +93,11 @@ Parameters:
   SnapshotRepository:
     Description: S3 bucket name for elasticsearch snapshots repository
     Type: String
+  SnapshotRepositoryEncryption:
+    Description: Whether to apply server side encryption snapshots stored in S3
+    Default: true
+    Type: String
+    AllowedValues: [true, false]
   IndexKeepDays:
     Description: Keep elasticsearch indices for x number of days
     Type: Number
@@ -473,7 +478,8 @@ Resources:
                   "type": "s3", \
                   "settings": { \
                     "bucket": "${ElkS3Bucket}", \
-                    "region": "${AWS::Region}" \
+                    "region": "${AWS::Region}", \
+                    "server_side_encryption": "${SnapshotRepositoryEncryption}" \
                   } \
                 }'
                 curl 'http://localhost:9200/_snapshot/s3?pretty'

--- a/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.yml
+++ b/cloudformation/ELK_Stack_Multi_AZ_in_Private_VPC.yml
@@ -94,7 +94,7 @@ Parameters:
     Description: S3 bucket name for elasticsearch snapshots repository
     Type: String
   SnapshotRepositoryEncryption:
-    Description: Whether to apply server side encryption snapshots stored in S3
+    Description: Whether to apply server side encryption to snapshots stored in S3
     Default: true
     Type: String
     AllowedValues: [true, false]


### PR DESCRIPTION
Adds the ability to upload snapshot data with encryption (S3 managed key is the only option, no KMS AFAICT).  

I've used a parameter but we could make this non-optional as it should be totally transparent.